### PR TITLE
Update glewlwyd.h

### DIFF
--- a/src/glewlwyd.h
+++ b/src/glewlwyd.h
@@ -32,8 +32,14 @@
 #include <jansson.h>
 #include <jwt.h>
 
-#define _GNU_SOURCE
-#define __USE_GNU
+#ifndef _GNU_SOURCE
+ #define _GNU_SOURCE
+#endif
+
+#ifndef __USE_GNU
+ #define __USE_GNU
+#endif
+
 #include <crypt.h>
 #include <stdio.h>
 


### PR DESCRIPTION
Fix compiler warning of redefinition of the _GNU_SOURCE, __USE_GNU when integrated into a larger project.