### PR TITLE
Update glewlwyd.mariadb.sql

### DIFF
--- a/glewlwyd.mariadb.sql
+++ b/glewlwyd.mariadb.sql
@@ -99,7 +99,7 @@ CREATE TABLE `g_reset_password` (
   `grp_token` VARCHAR(512) NOT NULL,
   `grp_enabled` TINYINT(1) DEFAULT 1,
   `grp_issued_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  `grp_reset_at` TIMESTAMP
+  `grp_reset_at` TIMESTAMP NULL
 );
 CREATE INDEX `i_g_reset_password_username` ON `g_reset_password`(`grp_username`);
 
@@ -114,8 +114,8 @@ CREATE TABLE `g_refresh_token` (
   `grt_authorization_type` INT(2) NOT NULL, -- 0: Authorization Code Grant, 1: Implicit Grant, 2: Resource Owner Password Credentials Grant, 3: Client Credentials Grant
   `grt_username` VARCHAR(128) NOT NULL,
   `grt_issued_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  `grt_last_seen` TIMESTAMP,
-  `grt_expired_at` TIMESTAMP,
+  `grt_last_seen` TIMESTAMP NULL,
+  `grt_expired_at` TIMESTAMP NULL,
   `grt_ip_source` VARCHAR(64) NOT NULL,
   `grt_enabled` TINYINT(1) DEFAULT 1
 );
@@ -137,8 +137,8 @@ CREATE TABLE `g_session` (
   `gss_hash` VARCHAR(128) NOT NULL,
   `gss_username` VARCHAR(128) NOT NULL,
   `gss_issued_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  `gss_last_seen` TIMESTAMP,
-  `gss_expired_at` TIMESTAMP,
+  `gss_last_seen` TIMESTAMP NULL,
+  `gss_expired_at` TIMESTAMP NULL,
   `gss_ip_source` VARCHAR(64) NOT NULL,
   `gss_enabled` TINYINT(1) DEFAULT 1
 );


### PR DESCRIPTION
Making TIMESTAMP to be NULL.
Refer to issue https://github.com/babelouest/glewlwyd/issues/7

@babelouest , I tested with TIMESTAMP DEFAULT NULL, and it did not fix the problem. Importing the schema failed again with DEFAULT NULL.

So, I had to revert it to TIMESTAMP NULL.

You may please check the same in your MySQL servers.

Please ignore earlier pull request on this subject. Please consider this if that fits to your views. 