### PR TITLE
Update glewlwyd.conf.sample

### DIFF
--- a/glewlwyd.conf.sample
+++ b/glewlwyd.conf.sample
@@ -61,6 +61,10 @@ static_files_mime_types =
   {
     extension = ".map"
     type = "application/octet-stream"
+  },
+  {
+    extension = ".ico"
+    type = "image/x-icon"
   }
 )
 


### PR DESCRIPTION
When running the sever, there is a warning of unknown mime type for favicon.ico.
2017-03-06T10:42:38 - Glewlwyd WARNING: Static File Server - Unknown mime type for extension .ico