### PR TITLE
clang sanitizer

### DIFF
--- a/src/glewlwyd.c
+++ b/src/glewlwyd.c
@@ -274,6 +274,10 @@ int main (int argc, char ** argv) {
 void exit_server(struct config_elements ** config, int exit_value) {
 
   if (config != NULL && *config != NULL) {
+    /* stop framework */
+    ulfius_stop_framework((*config)->instance);
+    ulfius_clean_instance((*config)->instance);
+    o_free((*config)->instance);
     // Cleaning data
     o_free((*config)->config_file);
     o_free((*config)->url_prefix);
@@ -352,9 +356,6 @@ void exit_server(struct config_elements ** config, int exit_value) {
     }
     h_close_db((*config)->conn);
     h_clean_connection((*config)->conn);
-    ulfius_stop_framework((*config)->instance);
-    ulfius_clean_instance((*config)->instance);
-    o_free((*config)->instance);
     y_close_logs();
     
     o_free(*config);

--- a/src/glewlwyd.c
+++ b/src/glewlwyd.c
@@ -550,7 +550,7 @@ void print_help(FILE * output) {
  * I don't like global variables but it looks fine to people who designed this
  */
 void exit_handler(int signal) {
-  y_log_message(Y_LOG_LEVEL_INFO, "Glewlwyd caught a stop or kill signal (%d), exiting", signal);
+  //y_log_message(Y_LOG_LEVEL_INFO, "Glewlwyd caught a stop or kill signal (%d), exiting", signal);
   pthread_mutex_lock(&global_handler_close_lock);
   pthread_cond_signal(&global_handler_close_cond);
   pthread_mutex_unlock(&global_handler_close_lock);


### PR DESCRIPTION
The thread sainitizer of clang complains about:
==================
WARNING: ThreadSanitizer: signal-unsafe call inside of a signal (pid=26386)
    #0 malloc ??:? (glewlwyd+0x43dd9f)
    #1 y_log_message ??:? (libyder.so.2.0+0x1a11)
    #2 __tsan::CallUserSignalHandler(__tsan::ThreadState*, bool, bool, bool, int, __sanitizer::__sanitizer_siginfo*, void*) tsan_interceptors.cc.o:? (glewlwyd+0x428613)
    #3 main /root/glewlwyd/glewlwyd-upstream/glewlwyd/src/glewlwyd.c:257 (glewlwyd+0x55b78a)

SUMMARY: ThreadSanitizer: signal-unsafe call inside of a signal ??:? in __interceptor_malloc
==================
==================
WARNING: ThreadSanitizer: signal-unsafe call inside of a signal (pid=26386)
    #0 malloc ??:? (glewlwyd+0x43dd9f)
    #1 open_memstream ??:? (libc.so.6+0x772a9)
    #2 __tsan::CallUserSignalHandler(__tsan::ThreadState*, bool, bool, bool, int, __sanitizer::__sanitizer_siginfo*, void*) tsan_interceptors.cc.o:? (glewlwyd+0x428613)
    #3 main /root/glewlwyd/glewlwyd-upstream/glewlwyd/src/glewlwyd.c:257 (glewlwyd+0x55b78a)

SUMMARY: ThreadSanitizer: signal-unsafe call inside of a signal ??:? in __interceptor_malloc
==================
==================
WARNING: ThreadSanitizer: signal-unsafe call inside of a signal (pid=26386)
    #0 calloc ??:? (glewlwyd+0x442b44)
    #1 open_memstream ??:? (libc.so.6+0x772d2)
    #2 __tsan::CallUserSignalHandler(__tsan::ThreadState*, bool, bool, bool, int, __sanitizer::__sanitizer_siginfo*, void*) tsan_interceptors.cc.o:? (glewlwyd+0x428613)
    #3 main /root/glewlwyd/glewlwyd-upstream/glewlwyd/src/glewlwyd.c:257 (glewlwyd+0x55b78a)

SUMMARY: ThreadSanitizer: signal-unsafe call inside of a signal ??:? in calloc
==================
(...)

so don't use y_* in the signal handler.


There is also some stuff like this:
==================
WARNING: ThreadSanitizer: data race (pid=30300)
  Write of size 8 at 0x7b0400002460 by main thread:
    #0 free ??:? (glewlwyd+0x4454cd)
    #1 exit_server /root/glewlwyd/glewlwyd-upstream/glewlwyd/src/glewlwyd.c:285 (glewlwyd+0x55c08d)
    #2 main /root/glewlwyd/glewlwyd-upstream/glewlwyd/src/glewlwyd.c:268 (glewlwyd+0x55b89c)

  Previous read of size 1 at 0x7b0400002466 by thread T7:
    #0 strlen ??:? (glewlwyd+0x42c596)
    #1 access_token_check_scope_admin /root/glewlwyd/glewlwyd-upstream/glewlwyd/src/token.c:680 (glewlwyd+0x4dd2d0)
    #2 callback_glewlwyd_check_scope_admin /root/glewlwyd/glewlwyd-upstream/glewlwyd/src/webservice.c:363 (glewlwyd+0x4c8bea)
    #3 yuarel_parse_query ??:? (libulfius.so.2.4+0xeb29)

  Thread T7 'MHD-connection' (tid=30755, finished) created by thread T1 at:
    #0 pthread_create ??:? (glewlwyd+0x42b8b6)
    #1 MHD_free ??:? (libmicrohttpd.so.12+0x12976)

SUMMARY: ThreadSanitizer: data race ??:? in __interceptor_free
==================


This is because in exit_server some stuff is freed while it is still accessible in the ulfius thread.