### PR TITLE
cmake: fix finding location of liboath/oath.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -374,7 +374,7 @@ if (WITH_SCHEME_OTP)
 	find_package(LibOath REQUIRED)
 	if (LIBOATH_FOUND)
 			set(MOD_LIBS ${LIBOATH_LIBRARIES})
-			include_directories(${LIBOATH_INCLUDE_DIRS})
+			include_directories(${LIBOATH_INCLUDE_DIR})
 	endif ()
 	
 	set(LIB_SRC ${CMAKE_CURRENT_SOURCE_DIR}/src/glewlwyd-common.h ${CMAKE_CURRENT_SOURCE_DIR}/src/misc.c ${SCHEME_MODULES_SRC_PATH}/otp.c)

--- a/cmake-modules/FindLibOath.cmake
+++ b/cmake-modules/FindLibOath.cmake
@@ -33,7 +33,7 @@ find_package(PkgConfig QUIET)
 pkg_check_modules(PC_LIBOATH QUIET liboath)
 
 find_path(LIBOATH_INCLUDE_DIR
-        NAMES oath.h
+        NAMES liboath/oath.h
         HINTS ${PC_LIBOATH_INCLUDEDIR} ${PC_LIBOATH_INCLUDE_DIRS})
 
 find_library(LIBOATH_LIBRARY


### PR DESCRIPTION
I think this fixed a build problem for me.