### PR TITLE
oidc: support array-of-strings user property

### DIFF
--- a/src/glewlwyd-common.h
+++ b/src/glewlwyd-common.h
@@ -395,6 +395,12 @@ int generate_digest_pbkdf2(const char * data, const char * salt, char * out_dige
 int check_result_value(json_t * result, const int value);
 
 /**
+ * CHeck if the json array is either empty or only contains elements
+ * of type.
+ */
+int check_uniform_json_array(json_t * j_array, json_type t);
+
+/**
  * Modules functions prototypes
  */
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -510,3 +510,18 @@ int check_result_value(json_t * result, const int value) {
   return (json_is_integer(json_object_get(result, "result")) && 
           json_integer_value(json_object_get(result, "result")) == value);
 }
+
+/**
+ * CHeck if the json array is either empty or only contains elements
+ * of type.
+ */
+ int check_uniform_json_array(json_t * j_array, json_type t) {
+  json_t * j_element = NULL;
+  size_t index = 0;
+  json_array_foreach(j_array, index, j_element) {
+    if (j_element->type != t) {
+      return G_ERROR;
+    }
+  }
+  return G_OK;
+ }


### PR DESCRIPTION
I noticed that the "user group" support in the standard Jenkins OIDC plugin relies on the userdata having an array property.  So I set out to create support for a custom array-of-strings property in glewlwyd.