### PR TITLE
Define global variables in .c, declare extern in .h

### DIFF
--- a/src/glewlwyd.c
+++ b/src/glewlwyd.c
@@ -38,8 +38,8 @@
 
 #include "glewlwyd.h"
 
-pthread_mutex_t global_handler_close_lock;
-pthread_cond_t  global_handler_close_cond;
+static pthread_mutex_t global_handler_close_lock;
+static pthread_cond_t  global_handler_close_cond;
 
 /**
  *

--- a/src/glewlwyd.c
+++ b/src/glewlwyd.c
@@ -38,6 +38,9 @@
 
 #include "glewlwyd.h"
 
+pthread_mutex_t global_handler_close_lock;
+pthread_cond_t  global_handler_close_cond;
+
 /**
  *
  * Main function

--- a/src/glewlwyd.h
+++ b/src/glewlwyd.h
@@ -135,9 +135,6 @@
 #define GLEWLWYD_ENV_DATABASE_SQLITE3_PATH      "GLWD_DATABASE_SQLITE3_PATH"
 #define GLEWLWYD_ENV_DATABASE_POSTGRE_CONNINFO  "GLWD_DATABASE_POSTGRE_CONNINFO"
 
-extern pthread_mutex_t global_handler_close_lock;
-extern pthread_cond_t  global_handler_close_cond;
-
 // Main functions and misc functions
 int build_config_from_env(struct config_elements * config);
 int  build_config_from_file(struct config_elements * config);

--- a/src/glewlwyd.h
+++ b/src/glewlwyd.h
@@ -135,8 +135,8 @@
 #define GLEWLWYD_ENV_DATABASE_SQLITE3_PATH      "GLWD_DATABASE_SQLITE3_PATH"
 #define GLEWLWYD_ENV_DATABASE_POSTGRE_CONNINFO  "GLWD_DATABASE_POSTGRE_CONNINFO"
 
-pthread_mutex_t global_handler_close_lock;
-pthread_cond_t  global_handler_close_cond;
+extern pthread_mutex_t global_handler_close_lock;
+extern pthread_cond_t  global_handler_close_cond;
 
 // Main functions and misc functions
 int build_config_from_env(struct config_elements * config);


### PR DESCRIPTION
When the variables are defined in the header, different object files that use the header will contain different instances of the variable. The linker might unify those copies later, but it's more correct to only define each variable once in a `.c` file.