### PR TITLE
Use a dedicated thread to process signals

### DIFF
--- a/src/glewlwyd.c
+++ b/src/glewlwyd.c
@@ -1536,30 +1536,28 @@ void* signal_thread(void *arg) {
   sigset_t *sigs = arg;
   int res, signum;
 
-  while (1) {
-    res = sigwait(sigs, &signum);
-    if (res) {
-      y_log_message(Y_LOG_LEVEL_ERROR, "Glewlwyd - Waiting for signals failed");
-      exit(1);
-    }
-    if (signum == SIGQUIT || signum == SIGINT || signum == SIGTERM || signum == SIGHUP) {
-      y_log_message(Y_LOG_LEVEL_INFO, "Glewlwyd - Received close signal: %s", strsignal(signum));
-      pthread_mutex_lock(&global_handler_close_lock);
-      pthread_cond_signal(&global_handler_close_cond);
-      pthread_mutex_unlock(&global_handler_close_lock);
-      return NULL;
-    } else if (signum == SIGBUS) {
-      fprintf(stderr, "Glewlwyd - Received bus error signal\n");
-      exit(256-signum);
-    } else if (signum == SIGSEGV) {
-      fprintf(stderr, "Glewlwyd - Received segmentation fault signal\n");
-      exit(256-signum);
-    } else if (signum == SIGILL) {
-      fprintf(stderr, "Glewlwyd - Received illegal instruction signal\n");
-      exit(256-signum);
-    } else {
-      y_log_message(Y_LOG_LEVEL_WARNING, "Glewlwyd - Received unexpected signal: %s", strsignal(signum));
-    }
+  res = sigwait(sigs, &signum);
+  if (res) {
+    y_log_message(Y_LOG_LEVEL_ERROR, "Glewlwyd - Waiting for signals failed");
+    exit(1);
+  }
+  if (signum == SIGQUIT || signum == SIGINT || signum == SIGTERM || signum == SIGHUP) {
+    y_log_message(Y_LOG_LEVEL_INFO, "Glewlwyd - Received close signal: %s", strsignal(signum));
+    pthread_mutex_lock(&global_handler_close_lock);
+    pthread_cond_signal(&global_handler_close_cond);
+    pthread_mutex_unlock(&global_handler_close_lock);
+    return NULL;
+  } else if (signum == SIGBUS) {
+    fprintf(stderr, "Glewlwyd - Received bus error signal\n");
+    exit(256-signum);
+  } else if (signum == SIGSEGV) {
+    fprintf(stderr, "Glewlwyd - Received segmentation fault signal\n");
+    exit(256-signum);
+  } else if (signum == SIGILL) {
+    fprintf(stderr, "Glewlwyd - Received illegal instruction signal\n");
+    exit(256-signum);
+  } else {
+    y_log_message(Y_LOG_LEVEL_WARNING, "Glewlwyd - Received unexpected signal: %s", strsignal(signum));
   }
 }
 

--- a/src/glewlwyd.c
+++ b/src/glewlwyd.c
@@ -1538,10 +1538,10 @@ void* signal_thread(void *arg) {
 
   while (1) {
     res = sigwait(sigs, &signum);
-	 if (res) {
+    if (res) {
       y_log_message(Y_LOG_LEVEL_ERROR, "Glewlwyd - Waiting for signals failed");
-		exit(1);
-	 }
+      exit(1);
+    }
     if (signum == SIGQUIT || signum == SIGINT || signum == SIGTERM || signum == SIGHUP) {
       y_log_message(Y_LOG_LEVEL_INFO, "Glewlwyd - Received close signal: %s", strsignal(signum));
       pthread_mutex_lock(&global_handler_close_lock);

--- a/src/glewlwyd.c
+++ b/src/glewlwyd.c
@@ -38,8 +38,6 @@
 
 #include "glewlwyd.h"
 
-void* signal_thread(void *arg);
-
 static pthread_mutex_t global_handler_close_lock;
 static pthread_cond_t  global_handler_close_cond;
 

--- a/src/glewlwyd.c
+++ b/src/glewlwyd.c
@@ -1538,7 +1538,7 @@ void* signal_thread(void *arg) {
 
   res = sigwait(sigs, &signum);
   if (res) {
-    y_log_message(Y_LOG_LEVEL_ERROR, "Glewlwyd - Waiting for signals failed");
+    fprintf(stderr, "Glewlwyd - Waiting for signals failed\n");
     exit(1);
   }
   if (signum == SIGQUIT || signum == SIGINT || signum == SIGTERM || signum == SIGHUP) {

--- a/src/glewlwyd.c
+++ b/src/glewlwyd.c
@@ -1559,6 +1559,8 @@ void* signal_thread(void *arg) {
   } else {
     y_log_message(Y_LOG_LEVEL_WARNING, "Glewlwyd - Received unexpected signal: %s", strsignal(signum));
   }
+
+  return NULL;
 }
 
 int module_instance_parameters_check(const char * module_parameters, const char * instance_parameters) {

--- a/src/glewlwyd.c
+++ b/src/glewlwyd.c
@@ -185,14 +185,17 @@ int main (int argc, char ** argv) {
   }
 
   // Process end signals on dedicated thread
-  sigemptyset(&close_signals);
-  sigaddset(&close_signals, SIGQUIT);
-  sigaddset(&close_signals, SIGINT);
-  sigaddset(&close_signals, SIGTERM);
-  sigaddset(&close_signals, SIGHUP);
-  sigaddset(&close_signals, SIGBUS);
-  sigaddset(&close_signals, SIGSEGV);
-  sigaddset(&close_signals, SIGILL);
+  if (sigemptyset(&close_signals) == -1 ||
+      sigaddset(&close_signals, SIGQUIT) == -1 ||
+      sigaddset(&close_signals, SIGINT) == -1 ||
+      sigaddset(&close_signals, SIGTERM) == -1 ||
+      sigaddset(&close_signals, SIGHUP) == -1 ||
+      sigaddset(&close_signals, SIGBUS) == -1 ||
+      sigaddset(&close_signals, SIGSEGV) == -1 ||
+      sigaddset(&close_signals, SIGILL) == -1) {
+    fprintf(stderr, "init - Error creating signal mask\n");
+    exit_server(&config, GLEWLWYD_ERROR);
+  }
   if (pthread_sigmask(SIG_BLOCK, &close_signals, NULL)) {
     fprintf(stderr, "init - Error setting signal mask\n");
     exit_server(&config, GLEWLWYD_ERROR);

--- a/src/glewlwyd.c
+++ b/src/glewlwyd.c
@@ -1554,6 +1554,8 @@ void* signal_thread(void *arg) {
     } else if (signum == SIGILL) {
       y_log_message(Y_LOG_LEVEL_ERROR, "Glewlwyd - Received illegal instruction signal");
       exit(256-signum);
+    } else {
+      y_log_message(Y_LOG_LEVEL_WARNING, "Glewlwyd - Received unexpected signal: %s", strsignal(signum));
     }
   }
 }

--- a/src/glewlwyd.c
+++ b/src/glewlwyd.c
@@ -1546,13 +1546,13 @@ void* signal_thread(void *arg) {
       pthread_mutex_unlock(&global_handler_close_lock);
       return NULL;
     } else if (signum == SIGBUS) {
-      y_log_message(Y_LOG_LEVEL_ERROR, "Glewlwyd - Received bus error signal");
+      fprintf(stderr, "Glewlwyd - Received bus error signal\n");
       exit(256-signum);
     } else if (signum == SIGSEGV) {
-      y_log_message(Y_LOG_LEVEL_ERROR, "Glewlwyd - Received segmentation fault signal");
+      fprintf(stderr, "Glewlwyd - Received segmentation fault signal\n");
       exit(256-signum);
     } else if (signum == SIGILL) {
-      y_log_message(Y_LOG_LEVEL_ERROR, "Glewlwyd - Received illegal instruction signal");
+      fprintf(stderr, "Glewlwyd - Received illegal instruction signal\n");
       exit(256-signum);
     } else {
       y_log_message(Y_LOG_LEVEL_WARNING, "Glewlwyd - Received unexpected signal: %s", strsignal(signum));

--- a/src/glewlwyd.h
+++ b/src/glewlwyd.h
@@ -140,7 +140,7 @@ int build_config_from_env(struct config_elements * config);
 int  build_config_from_file(struct config_elements * config);
 int build_config_from_args(int argc, char ** argv, struct config_elements * config, int * use_config_file, int * use_config_env);
 int  check_config(struct config_elements * config);
-void exit_handler(int handler);
+void* signal_thread(void *arg);
 void exit_server(struct config_elements ** config, int exit_value);
 void print_help(FILE * output);
 char * get_file_content(const char * file_path);


### PR DESCRIPTION
I put the signal handling in a dedicated thread which should be able to use malloc/logging/... without causing problems. (See #103)

Handling SIGSGEV/SIGILL/SIGBUS is implemented but likely pointless: If a thread runs into an instruction that triggers one of those it will be impossible for the thread to continue even though the signal is blocked for the thread. The kernel will the quickly kill the program despite the blocked signal, most likely before the signal thread gets a chance to run.

I made `close_signals` static to make sure it doesn't go out of scope while the signal thread might still be running.