### PR TITLE
Incorrect field type in New User Plugin registration form

### DIFF
--- a/webapp-src/src/Admin/RegisterParams.js
+++ b/webapp-src/src/Admin/RegisterParams.js
@@ -538,7 +538,7 @@ class RegisterParams extends Component {
               <div className="input-group-prepend">
                 <label className="input-group-text" htmlFor="mod-register-verification-code-duration">{i18next.t("admin.mod-register-verification-code-duration")}</label>
               </div>
-              <input type="number" min="0" max="65536" step="1" className={this.state.errorList["verification-code-duration"]?"form-control is-invalid":"form-control"} id="mod-register-verification-code-duration" onChange={(e) => this.changeParam(e, "verification-code-duration")} value={this.state.mod.parameters["verification-code-duration"]} placeholder={i18next.t("admin.mod-register-verification-code-duration-ph")} />
+              <input type="number" min="0" max="65536" step="1" className={this.state.errorList["verification-code-duration"]?"form-control is-invalid":"form-control"} id="mod-register-verification-code-duration" onChange={(e) => this.changeParam(e, "verification-code-duration", true)} value={this.state.mod.parameters["verification-code-duration"]} placeholder={i18next.t("admin.mod-register-verification-code-duration-ph")} />
             </div>
             {this.state.errorList["verification-code-duration"]?<span className="error-input">{this.state.errorList["verification-code-duration"]}</span>:""}
           </div>


### PR DESCRIPTION
Form currently fails because `verification-code-duration` is of type integer, while the event handler expects a non-integer.