### PR TITLE
Default to auto-detected language in user registration email.

### DIFF
--- a/webapp-src/src/Profile/App.js
+++ b/webapp-src/src/Profile/App.js
@@ -187,7 +187,9 @@ class App extends Component {
     apiManager.glewlwydRequest("/" + this.state.config.params.register + "/config")
     .then((config) => {
       var defaultLang = false;
-      if (config.languages.length) {
+      if (this.state.lang) {
+        defaultLang = this.state.lang;
+      } else if (config.languages.length) {
         defaultLang = config.languages[0];
       }
       this.setState({registerValid: true, registerConfig: config, registerDefaultLang: defaultLang}, () => {


### PR DESCRIPTION
The email address confirmation button in the user registration form currently defaults to `config.languages[0]`.

With this PR, new users will be proposed to receive their confirmation email in the language of the UI, typically as autodetected by `i18next-browser-languageDetector`. (To be sure, I am also keeping `config.languages[0]` as a fallback, although I cannot imagine any conditions under which it would be useful; please feel free to trim if/as necessary.)

The user remains free to select an alternative email language. That said, I wouldn't be against the removal of button altogether. Isn't it safe to assume that the UI language applies to emails, as well?

Thanks!

PS: Side-question: Do I understand correctly that a `lang` field is attached to each user in the database? If so, when is it set and updated?

