### PR TITLE
Use no-referrer policy instead of noreferrer (per W3C).

### DIFF
--- a/webapp-src/callback.html
+++ b/webapp-src/callback.html
@@ -8,7 +8,7 @@
     <meta name="description" content="Glewlwyd SSO Authorization Server">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="robots" content="noindex,nofollow">
-    <meta name="referrer" content="noreferrer">
+    <meta name="referrer" content="no-referrer">
 
     <link rel="stylesheet" href="css/bootstrap.min.css">
     <link rel="stylesheet" href="css/font-awesome.min.css">

--- a/webapp-src/index.html
+++ b/webapp-src/index.html
@@ -8,7 +8,7 @@
     <meta name="description" content="Glewlwyd SSO Authorization Server">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="robots" content="noindex,nofollow">
-    <meta name="referrer" content="noreferrer">
+    <meta name="referrer" content="no-referrer">
 
     <link rel="stylesheet" href="css/bootstrap.min.css">
     <link rel="stylesheet" href="css/font-awesome.min.css">

--- a/webapp-src/login.html
+++ b/webapp-src/login.html
@@ -8,7 +8,7 @@
     <meta name="description" content="Glewlwyd SSO Authorization Server">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="robots" content="noindex,nofollow">
-    <meta name="referrer" content="noreferrer">
+    <meta name="referrer" content="no-referrer">
 
     <link rel="stylesheet" href="css/bootstrap.min.css">
     <link rel="stylesheet" href="css/font-awesome.min.css">

--- a/webapp-src/profile.html
+++ b/webapp-src/profile.html
@@ -8,7 +8,7 @@
     <meta name="description" content="Glewlwyd SSO Authorization Server">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="robots" content="noindex,nofollow">
-    <meta name="referrer" content="noreferrer">
+    <meta name="referrer" content="no-referrer">
 
     <link rel="stylesheet" href="css/bootstrap.min.css">
     <link rel="stylesheet" href="css/font-awesome.min.css">


### PR DESCRIPTION
`<meta name="referrer" content="noreferrer">` triggers a browser console error since `noreferrer` is not a valid value. This PR fixes the issue and prevents fallbacks to the less secure default (`no-referrer-when-downgrade`).