### PR TITLE
Adds find_package to libmicrohttpd and fix a typo in FindMHD.cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,13 @@ if (LIBCONFIG_FOUND)
 	include_directories(${LIBCONFIG_INCLUDE_DIRS})
 endif ()
 
+include(FindMHD)
+find_package(MHD REQUIRED)
+if (MHD_FOUND)
+	set(GLWD_LIBS ${GLWD_LIBS} ${MHD_LIBRARIES})
+	include_directories(${MHD_INCLUDE_DIRS})
+endif ()
+
 # build
 
 add_executable(glewlwyd ${CMAKE_CURRENT_SOURCE_DIR}/src/glewlwyd.h

--- a/cmake-modules/FindMHD.cmake
+++ b/cmake-modules/FindMHD.cmake
@@ -1,5 +1,5 @@
 #.rst:
-# FindJansson
+# FindMHD
 # -----------
 #
 # Find libmicrohttpd
@@ -58,7 +58,7 @@ elseif (MHD_INCLUDE_DIR AND EXISTS "${MHD_INCLUDE_DIR}/microhttpd.h")
 endif ()
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(mhd
+find_package_handle_standard_args(MHD
         REQUIRED_VARS MHD_LIBRARY MHD_INCLUDE_DIR
         VERSION_VAR MHD_VERSION_STRING)
 


### PR DESCRIPTION
Hi, i was trying to compile **glewlwyd** and got the error below:

```
[  4%] Built target orcania
[  6%] Built target yder
[ 13%] Built target hoel
[ 14%] Building C object ulfius-build/CMakeFiles/ulfius.dir/src/u_map.c.o
In file included from /home/faustocarva/gits/faustocarva/glewlwyd/ulfius-src/include/u_private.h:29,
                 from /home/faustocarva/gits/faustocarva/glewlwyd/ulfius-src/src/u_map.c:30:
/home/faustocarva/gits/faustocarva/glewlwyd/ulfius-src/include/ulfius.h:55:10: fatal error: microhttpd.h: No such file or directory
   55 | #include <microhttpd.h>
      |          ^~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [ulfius-build/CMakeFiles/ulfius.dir/build.make:63: ulfius-build/CMakeFiles/ulfius.dir/src/u_map.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:912: ulfius-build/CMakeFiles/ulfius.dir/all] Error 2
make: *** [Makefile:152: all] Error 2
```

So i inserted a `find_package` command  (like others in this project) into  `CMakeLists.txt`. I also found that `FindMHD.cmake` had a typo to "mhd" (it needed to be MHD in capital letters) and this made the cmake process go over and not stop when needed. 

Thanks for your project.