### PR TITLE
Bug fixes for the Edit User modal

### DIFF
--- a/webapp-src/src/Admin/App.js
+++ b/webapp-src/src/Admin/App.js
@@ -1309,6 +1309,28 @@ class App extends Component {
   }
 
 	render() {
+    // Object deep-copy function culled from https://medium.com/javascript-in-plain-english/how-to-deep-copy-objects-and-arrays-in-javascript-7c911359b089
+    const deepCopyFunction = (inObject) => {
+      let outObject, value, key
+
+      if (typeof inObject !== "object" || inObject === null) {
+        return inObject // Return the value if inObject is not an object
+      }
+
+      // Create an array or object to hold the values
+      outObject = Array.isArray(inObject) ? [] : {}
+
+      for (key in inObject) {
+        value = inObject[key]
+
+        // Recursively (deep) copy for nested objects, including arrays
+        outObject[key] = deepCopyFunction(value)
+      }
+
+      return outObject
+    }
+    var dataCopy = deepCopyFunction(this.state.editModal.data);
+
     var invalidCredentialMessage;
     if (this.state.invalidCredentialMessage) {
       invalidCredentialMessage = <div className="alert alert-danger" role="alert">{i18next.t("admin.error-credential-message")}</div>
@@ -1351,7 +1373,7 @@ class App extends Component {
           </div>
           <Notification loggedIn={this.state.loggedIn}/>
           <Confirm title={this.state.confirmModal.title} message={this.state.confirmModal.message} callback={this.state.confirmModal.callback} />
-          <EditRecord title={this.state.editModal.title} pattern={this.state.editModal.pattern} source={this.state.editModal.source} data={this.state.editModal.data} callback={this.state.editModal.callback} validateCallback={this.state.editModal.validateCallback} add={this.state.editModal.add} />
+          <EditRecord title={this.state.editModal.title} pattern={this.state.editModal.pattern} source={this.state.editModal.source} data={dataCopy} callback={this.state.editModal.callback} validateCallback={this.state.editModal.validateCallback} add={this.state.editModal.add} />
           <ScopeEdit title={this.state.scopeModal.title} scope={this.state.scopeModal.data} add={this.state.scopeModal.add} modSchemes={this.state.modSchemes} callback={this.state.scopeModal.callback} />
           <ModEdit title={this.state.ModModal.title} role={this.state.ModModal.role} mod={this.state.ModModal.data} add={this.state.ModModal.add} types={this.state.ModModal.types} callback={this.state.ModModal.callback} config={this.state.config} />
           <PluginEdit title={this.state.PluginModal.title} mod={this.state.PluginModal.data} add={this.state.PluginModal.add} modSchemes={this.state.modSchemes} types={this.state.PluginModal.types} callback={this.state.PluginModal.callback} config={this.state.config} />

--- a/webapp-src/src/Modal/EditRecord.js
+++ b/webapp-src/src/Modal/EditRecord.js
@@ -546,7 +546,10 @@ class EditRecord extends Component {
       }
     });
     this.state.source.forEach((source, index) => {
-      if ((!curSource && !source.readonly) || source.name === this.state.data.source) {
+      if (!curSource && !source.readonly) {
+        curSource = '';
+      }
+      if (source.name === this.state.data.source) {
         curSource = source.display_name;
       }
       if (!source.readonly || source.name === this.state.data.source) {
@@ -590,7 +593,7 @@ class EditRecord extends Component {
           <div className="modal-footer">
             {hasError}
             <button type="button" className="btn btn-secondary" onClick={(e) => this.closeModal(e, false)}>{i18next.t("modal.close")}</button>
-            <button type="button" className="btn btn-primary " onClick={(e) => this.closeModal(e, true)} disabled={!this.state.data || !this.state.data.source || this.state.data.source.readonly || this.state.add}>{i18next.t("modal.ok")}</button>
+            <button type="button" className="btn btn-primary " onClick={(e) => this.closeModal(e, true)} disabled={!this.state.data || !this.state.data.source || this.state.data.source.readonly}>{i18next.t("modal.ok")}</button>
           </div>
         </div>
       </div>

--- a/webapp-src/src/Modal/EditRecord.js
+++ b/webapp-src/src/Modal/EditRecord.js
@@ -590,7 +590,7 @@ class EditRecord extends Component {
           <div className="modal-footer">
             {hasError}
             <button type="button" className="btn btn-secondary" onClick={(e) => this.closeModal(e, false)}>{i18next.t("modal.close")}</button>
-            <button type="button" className="btn btn-primary " onClick={(e) => this.closeModal(e, true)} disabled={this.state.data && this.state.data.source && !this.state.data.source.readonly && !this.state.add}>{i18next.t("modal.ok")}</button>
+            <button type="button" className="btn btn-primary " onClick={(e) => this.closeModal(e, true)} disabled={!this.state.data || !this.state.data.source || this.state.data.source.readonly || this.state.add}>{i18next.t("modal.ok")}</button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Squashes two bugs linked to the Edit User modal of the admin webapp:

1. The OK button would be disabled, preventing user info revisions from being saved into the database. If I'm not mistaken, this is because the `<button disable=` condition was the logical complement (`NOT`) of what it should have been.
2. Upon clicking on CLOSE, any user info revisions would still be reflected in the User List, even though are meant to be discarded and are indeed not saved in the database (refreshing the browser proves the point). To address this, I duplicate the `user` state object, thereby sandboxing any user info revisions within the modal, and preventing their propagation to other components (i.e. copy-by-reference is replaced by copy-by-value logic). There might be more elegant solutions to this bug.
