### PR TITLE
Accept and display profile images of any format.

### DIFF
--- a/webapp-src/config.json.sample
+++ b/webapp-src/config.json.sample
@@ -48,7 +48,7 @@
     },{
       "name": "picture",
       "list": false,
-      "type": "image/jpeg",
+      "type": "image/image",
       "forceShow": true,
       "edit": true,
       "label": "admin.user-picture",

--- a/webapp-src/src/Modal/EditRecord.js
+++ b/webapp-src/src/Modal/EditRecord.js
@@ -161,7 +161,7 @@ class EditRecord extends Component {
                 inputJsx = 
                 <div>
                   <div className="custom-file">
-                    <input type="file" className={"custom-file-input" + validInput} onChange={(e) => this.uploadImage(e, pattern.name, true)} id={"modal-image-" + pattern.name} />
+                    <input type="file" accept="image/*" className={"custom-file-input" + validInput} onChange={(e) => this.uploadImage(e, pattern.name, true)} id={"modal-image-" + pattern.name}/>
                     <label className="custom-file-label" htmlFor={"modal-image-" + pattern.name}>
                       {i18next.t("browse")}
                     </label>
@@ -252,7 +252,7 @@ class EditRecord extends Component {
             inputJsx = 
             <div>
               <div className="custom-file">
-                <input type="file" className={"custom-file-input" + validInput} onChange={(e) => this.uploadImage(e, pattern.name)} id={"modal-image-" + pattern.name} />
+                <input type="file" accept="image/*" className={"custom-file-input" + validInput} onChange={(e) => this.uploadImage(e, pattern.name)} id={"modal-image-" + pattern.name} />
                 <label className="custom-file-label" htmlFor={"modal-image-" + pattern.name}>
                   {i18next.t("browse")}
                 </label>

--- a/webapp-src/src/Profile/User.js
+++ b/webapp-src/src/Profile/User.js
@@ -260,7 +260,7 @@ class User extends Component {
               inputJsx = 
               <div>
                 <div className="custom-file">
-                  <input type="file" className={"custom-file-input" + validInput} onChange={(e) => this.uploadImage(e, pattern.name, true)} id={"modal-image-" + pattern.name} />
+                  <input type="file" className={"custom-file-input" + validInput} accept="image/*" onChange={(e) => this.uploadImage(e, pattern.name, true)} id={"modal-image-" + pattern.name} />
                   <label className="custom-file-label" htmlFor={"modal-image-" + pattern.name}>
                     {i18next.t("browse")}
                   </label>
@@ -380,7 +380,7 @@ class User extends Component {
           inputJsx = 
           <div>
             <div className="custom-file">
-              <input type="file" className={"custom-file-input" + validInput} onChange={(e) => this.uploadImage(e, pattern.name)} id={"modal-image-" + pattern.name} />
+              <input type="file" accept="image/*" className={"custom-file-input" + validInput} onChange={(e) => this.uploadImage(e, pattern.name)} id={"modal-image-" + pattern.name} />
               <label className="custom-file-label" htmlFor={"modal-image-" + pattern.name}>
                 {i18next.t("browse")}
               </label>

--- a/webapp/config.json.sample
+++ b/webapp/config.json.sample
@@ -48,7 +48,7 @@
     },{
       "name": "picture",
       "list": false,
-      "type": "image/jpeg",
+      "type": "image/image",
       "forceShow": true,
       "edit": true,
       "label": "admin.user-picture",


### PR DESCRIPTION
glewlwyd currently accepts only profile images of a single hard-wired format (JPEG by default). Uploading a different file format results in an invalid Base64 URI. Although it should be possible to detect the image type and adjust the Base64 URI accordingly, in this PR I am opting for the quickest possible workaround, namely an `accept="image/jpeg"` attribute for the image `<input>` tag. This solution is a proof of concept, so to say, and has two drawbacks: it does not accept X-PNG's or BMP's, and it remains fragile by not validating the image data on the server side. It's just a start to raise the issue. In a stronger solution, I think that the `picture` pattern MIME type would need to be modified to `"image/*` in `config.json`, the image upload routines modified to prepend the image type to the image URI, and the file contents examined/checksummed server-side to prevent invalid data from being stored.