### PR TITLE
UI tidbits

### DIFF
--- a/webapp-src/locales/en/translations.json
+++ b/webapp-src/locales/en/translations.json
@@ -42,6 +42,7 @@
     "error-value-expected": "Value required",
     "grant-title": "{{- client}} requires access to the following scopes",
     "grant": "Grant access",
+    "grant-none-available": "No grants have been requested",
     "grant-change-title": "Change grant scope for client",
     "grant-change": "Grant",
     "grant-auth-title": "Authenticate all access for the client",

--- a/webapp-src/locales/fr/translations.json
+++ b/webapp-src/locales/fr/translations.json
@@ -42,6 +42,7 @@
     "error-value-expected": "Valeur requise",
     "grant-title": "{{- client}} demande les droits d'accès suivants",
     "grant": "Autoriser l'accès",
+    "grant-none-available": "Aucune demande n'a été faite pour des droits d'accès",
     "grant-change-title": "Changer l'accès aux droits pour le client",
     "grant-change": "Droit d'accès",
     "grant-auth-title": "Autoriser tous les accès pour le client",

--- a/webapp-src/locales/nl/translations.json
+++ b/webapp-src/locales/nl/translations.json
@@ -42,6 +42,7 @@
     "error-value-expected": "Waarde vereist",
     "grant-title": "{{- client}} vraagt de volgende toegangsrechten",
     "grant": "Toegang toestaan",
+    "grant-none-available": "No grants have been requested",
     "grant-change-title": "Verander toegangsrechten voor de client",
     "grant-change": "Toestaan",
     "grant-auth-title": "Bevestig volledige toegang voor de client",

--- a/webapp-src/src/Admin/Navbar.js
+++ b/webapp-src/src/Admin/Navbar.js
@@ -97,6 +97,7 @@ class Navbar extends Component {
 
 	render() {
     var langList = [], profileList = [], profileDropdown, loginButton;
+    var profilePicture;
     this.state.config.lang.forEach((lang, i) => {
       if (lang === i18next.language) {
         langList.push(<a className="dropdown-item active" href="#" key={i}>{lang}</a>);
@@ -111,15 +112,40 @@ class Navbar extends Component {
     }
     profileList.push(<div className="dropdown-divider" key={profileList.length}></div>);
     profileList.push(<a className="dropdown-item" href="#" onClick={(e) => this.changeProfile(e, null)} key={profileList.length}>{i18next.t("profile.menu-session-new")}</a>);
-    profileDropdown = 
-    <div className="btn-group" role="group">
-      <button className="btn btn-secondary dropdown-toggle" type="button" id="dropdownProfile" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-        <i className="fas fa-user"></i>
-      </button>
-      <div className="dropdown-menu" aria-labelledby="dropdownProfile">
-        {profileList}
+    if (this.state.profileList) {
+      if (this.state.config.profilePicture && this.state.profileList[0][this.state.config.profilePicture.property]) {
+        var picData = this.state.profileList[0][this.state.config.profilePicture.property];
+        if (Array.isArray(picData)) {
+          picData = picData[0];
+        }
+        profilePicture =
+        <div style={{whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis"}}>
+          <img className="img-medium" style={{maxWidth: "30px", maxHeight: "21px", objectFit: "scale-down"}} src={"data:*;base64,"+picData}/>
+          &nbsp;
+        {this.state.profileList[0].username}
+        </div>
+      } else {
+        profilePicture =
+        <div style={{whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis"}}>
+          <img class="img-medium" style={{maxWidth: "1px"}} src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" /> {/*1-pixel transparent image as spacer (Possible Bootstrap bug)*/}
+          <i className="fas fa-user">
+            &nbsp;
+          </i>
+          {this.state.profileList[0].username}
+        </div>
+      }
+      profileDropdown = 
+      <div className="btn-group" role="group">
+        <button className="btn btn-secondary dropdown-toggle" type="button" id="dropdownProfile" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          <div style={{display: "block", float: "left"}}>
+            {profilePicture}
+          </div>
+        </button>
+        <div className="dropdown-menu" aria-labelledby="dropdownProfile">
+          {profileList}
+        </div>
       </div>
-    </div>
+    }
     if (this.state.loggedIn) {
       loginButton = <button type="button" className="btn btn-secondary" onClick={this.toggleLogin} title={i18next.t("title-logout")}>
         <i className="fas btn-icon fa-sign-out-alt"></i>

--- a/webapp-src/src/Login/App.js
+++ b/webapp-src/src/Login/App.js
@@ -333,7 +333,8 @@ class App extends Component {
                        newUser={this.state.newUser} 
                        newUserScheme={this.state.scheme} 
                        canContinue={this.state.canContinue} 
-                       schemeListRequired={this.state.schemeListRequired} />
+                       schemeListRequired={this.state.schemeListRequired}
+                       selectAccount={this.state.selectAccount} />
             </div>
           </div>
           <Notification loggedIn={true}/>

--- a/webapp-src/src/Login/Body.js
+++ b/webapp-src/src/Login/Body.js
@@ -66,6 +66,8 @@ class Body extends Component {
             <img className="btn-icon-right img-medium" src={"data:"+this.state.config.profilePicture.type+";base64,"+picData} alt={this.state.config.profilePicture.property} />
           </div>
         </div>
+    } else {
+      profilePicture = <div style={{textAlign: "center", fontSize: "48px"}}><i className="fas fa-user"></i></div>
     }
 		return (
       <div>

--- a/webapp-src/src/Login/Buttons.js
+++ b/webapp-src/src/Login/Buttons.js
@@ -103,7 +103,7 @@ class Buttons extends Component {
 	render() {
     var bAnother = "", asterisk = "", bContinue = "", registerTable = [];
     if (this.state.canContinue) {
-      bContinue = <button type="button" className="btn btn-primary" onClick={this.clickContinue} title={i18next.t("login.continue-title")}>
+      bContinue = <button type="button" className="btn btn-success" onClick={this.clickContinue} title={i18next.t("login.continue-title")}>
         <i className="fas fa-play btn-icon"></i>{i18next.t("login.continue")}
       </button>;
     }
@@ -130,7 +130,7 @@ class Buttons extends Component {
         });
       }
       bAnother = <div className="btn-group" role="group">
-        <button className="btn btn-primary dropdown-toggle" type="button" id="selectNewUser" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <button className="btn btn-secondary dropdown-toggle" type="button" id="selectNewUser" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
           <i className="fas fa-users btn-icon"></i>{i18next.t("login.login-another")}
         </button>
         <div className="dropdown-menu" aria-labelledby="selectNewUser">
@@ -142,10 +142,10 @@ class Buttons extends Component {
         </div>
       </div>;
   		return (
-        <div>
+        <div class="text-center">
           <div className="btn-group" role="group">
             {bContinue}
-            <button type="button" className="btn btn-primary" onClick={this.clickLogout}>
+            <button type="button" className="btn btn-danger" onClick={this.clickLogout}>
               <i className="fas fa-sign-out-alt btn-icon"></i>{i18next.t("login.logout")}
             </button>
           </div>
@@ -153,7 +153,7 @@ class Buttons extends Component {
             <hr/>
             <div className="btn-group" role="group">
               <div className="btn-group" role="group">
-                <button className="btn btn-primary dropdown-toggle" type="button" id="selectGrant" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <button className="btn btn-secondary dropdown-toggle" type="button" id="selectGrant" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                   <i className="fas fa-user-cog btn-icon"></i>{i18next.t("login.login-handle")}{asterisk}
                 </button>
                 <div className="dropdown-menu" aria-labelledby="selectGrant">

--- a/webapp-src/src/Login/Buttons.js
+++ b/webapp-src/src/Login/Buttons.js
@@ -18,7 +18,8 @@ class Buttons extends Component {
       schemeListRequired: props.schemeListRequired,
       bGrantTitle: props.showGrant?i18next.t("login.grant-auth-title"):i18next.t("login.grant-change-title"),
       bGrant: props.showGrant?i18next.t("login.grant-auth"):i18next.t("login.grant-change"),
-      showGrantAsterisk: props.showGrantAsterisk
+      showGrantAsterisk: props.showGrantAsterisk,
+      selectAccount: props.selectAccount
     };
 
     this.clickLogout = this.clickLogout.bind(this);
@@ -43,7 +44,8 @@ class Buttons extends Component {
       schemeListRequired: nextProps.schemeListRequired,
       bGrantTitle: nextProps.showGrant?i18next.t("login.grant-auth-title"):i18next.t("login.grant-change-title"),
       bGrant: nextProps.showGrant?i18next.t("login.grant-auth"):i18next.t("login.grant-change"),
-      showGrantAsterisk: nextProps.showGrantAsterisk
+      showGrantAsterisk: nextProps.showGrantAsterisk,
+      selectAccount: nextProps.selectAccount
     });
   }
 
@@ -111,7 +113,7 @@ class Buttons extends Component {
     if (this.state.showGrantAsterisk) {
       asterisk = <small><i className="fas fa-asterisk btn-icon-right"></i></small>;
     }
-    if (this.state.currentUser) {
+    if (this.state.currentUser && !this.state.selectAccount) {
       if (this.state.config.register) {
         this.state.config.register.forEach((register, index) => {
           registerTable.push(<a key={index} className="dropdown-item" href="#" onClick={(e) => this.registerNewUser(e, register.name)}>{i18next.t(register.message)}</a>);
@@ -147,22 +149,24 @@ class Buttons extends Component {
               <i className="fas fa-sign-out-alt btn-icon"></i>{i18next.t("login.logout")}
             </button>
           </div>
-          <hr/>
-          <div className="btn-group" role="group">
+          <div>
+            <hr/>
             <div className="btn-group" role="group">
-              <button className="btn btn-primary dropdown-toggle" type="button" id="selectGrant" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                <i className="fas fa-user-cog btn-icon"></i>{i18next.t("login.login-handle")}{asterisk}
-              </button>
-              <div className="dropdown-menu" aria-labelledby="selectGrant">
-                <a className="dropdown-item" href="#" onClick={this.clickGrant} alt={this.state.bGrantTitle}>
-                  {this.state.bGrant}
-                  {asterisk}
-                </a>
-                <div className="dropdown-divider"></div>
-                <a className="dropdown-item" href={this.state.config.ProfileUrl||""} target="_blank">{i18next.t("login.update-profile")}</a>
+              <div className="btn-group" role="group">
+                <button className="btn btn-primary dropdown-toggle" type="button" id="selectGrant" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                  <i className="fas fa-user-cog btn-icon"></i>{i18next.t("login.login-handle")}{asterisk}
+                </button>
+                <div className="dropdown-menu" aria-labelledby="selectGrant">
+                  <a className="dropdown-item" href="#" onClick={this.clickGrant} alt={this.state.bGrantTitle}>
+                    {this.state.bGrant}
+                    {asterisk}
+                  </a>
+                  <div className="dropdown-divider"></div>
+                  <a className="dropdown-item" href={this.state.config.ProfileUrl||""} target="_blank">{i18next.t("login.update-profile")}</a>
+                </div>
               </div>
+              {bAnother}
             </div>
-            {bAnother}
           </div>
         </div>
   		);

--- a/webapp-src/src/Login/GrantScope.js
+++ b/webapp-src/src/Login/GrantScope.js
@@ -89,10 +89,20 @@ class GrantScope extends Component {
       infoSomeScopeUnavailable = <div className="alert alert-info" role="alert">{i18next.t("login.info-some-scope-unavailable")}</div>
     }
     return (
+    (!Array.isArray(this.state.scope) || this.state.scope.length < 1)
+    ?
+    <div>
+      <div className="row">
+        <div className="col-md-12 text-center">
+          <h5>{i18next.t("login.grant-none-available")}</h5>
+        </div>
+      </div> 
+    </div>
+    :
     <div>
       <div className="row">
         <div className="col-md-12">
-          <b>{i18next.t("login.grant-title", {client: this.state.client.name})}</b>
+          <h5>{i18next.t("login.grant-title", {client: this.state.client.name})}</h5>
         </div>
       </div>
       <div className="row">
@@ -115,9 +125,9 @@ class GrantScope extends Component {
       <hr style={{borderTop: "0px"}}/>
       <div className="row">
         <div className="col-md-12">
-          <h5>
+          <b>
             {i18next.t("login.grant-info-message")}
-          </h5>
+          </b>
         </div>
       </div>
     </div>);

--- a/webapp-src/src/Login/GrantScope.js
+++ b/webapp-src/src/Login/GrantScope.js
@@ -92,7 +92,7 @@ class GrantScope extends Component {
     <div>
       <div className="row">
         <div className="col-md-12">
-          <h4>{i18next.t("login.grant-title", {client: this.state.client.name})}</h4>
+          <b>{i18next.t("login.grant-title", {client: this.state.client.name})}</b>
         </div>
       </div>
       <div className="row">
@@ -112,7 +112,7 @@ class GrantScope extends Component {
           <button type="button" className="btn btn-primary" onClick={this.handleGrantScope}>{i18next.t("login.grant")}</button>
         </div>
       </div>
-      <hr/>
+      <hr style={{borderTop: "0px"}}/>
       <div className="row">
         <div className="col-md-12">
           <h5>

--- a/webapp-src/src/Login/SchemeAuth.js
+++ b/webapp-src/src/Login/SchemeAuth.js
@@ -83,13 +83,13 @@ class SchemeAuth extends Component {
       }
       return (
       <div>
-        <div className="row">
-          <div className="col-md-12">
+        <div className="row text-center">
+          <div className="col-md-12 ">
             <h3>{connectMessage}</h3>
           </div>
         </div>
         <hr/>
-        <div className="row">
+        <div className="row text-center">
           <div className="col-md-12">
             <h4>{i18next.t("login.wish-message")}</h4>
           </div>

--- a/webapp-src/src/Login/SelectAccount.js
+++ b/webapp-src/src/Login/SelectAccount.js
@@ -63,39 +63,41 @@ class SelectAccount extends Component {
   }
   
   render() {
-    var userList = [];
+    var userList = [], userPicture;
     this.state.userList.forEach((user, index) => {
       var inputUser;
-      if (this.state.config.profilePicture && user[this.state.config.profilePicture.userProperty]) {
-        var picData = user[this.state.config.profilePicture.userProperty];
-        if (Array.isArray(picData)) {
-          picData = picData[0];
-        }
-        inputUser = 
-        <div>
-          <input type="radio" className="input-hidden" onChange={() => this.handleToggleGrantScope(user)} name="select-user" id={"select-user-" + user.username} checked={selected}/>
-          <label htmlFor={"select-user-" + user.username}>
-            <img className="img-thumb" src={"data:"+this.state.config.profilePicture.type+";base64,"+picData} alt={this.state.config.profilePicture.userProperty} />
+      if (user.picture) {
+        var picData = user.picture;
+        userPicture = <img style={{width: "30px", maxHeight: "21px", objectFit: "scale-down"}} className="img-thumb" src={"data:*;base64,"+picData} />
+      } else {
+        userPicture = <i className="fas fa-user" style={{fontSize: "24px"}}>&nbsp;</i>;
+      }
+      inputUser = 
+        <div className="input-group" id={"select-user-" + user.username}>
+          <label style={{width: "100%", marginBottom: "0", paddingLeft: "0", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis"}}>
+            <div className="col input-group-prepend" style={{display: "inline"}}>
+              {userPicture}
+            </div>
+            <input type="radio" className="input-hidden" onChange={() => this.handleToggleGrantScope(user)} name="select-user" checked={selected} />
+            <div className="col input-group-append" style={{display: "inline", paddingLeft: "0", paddingLeft: "0", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis"}}>
+              <div className="col btn-icon-left" style={{display: "inline", verticalAlign: "middle", paddingLeft: "0", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis"}}>
+                {user.name||user.username}
+              </div>
+              {/* The following invisible button contains a transparent pixel and is a hack for vertical alignment ("middle"). Pure CSS solution not found.*/}
+              <button type="button" disabled={true} class="btn btn-secondary" style={{visibility: "hidden", paddingLeft: "0", paddingRight: "0"}}>
+                <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z/C/HgAGgwJ/lK3Q6wAAAABJRU5ErkJggg=="/>
+              </button>
+            </div>
           </label>
         </div>
-      } else {
-        inputUser = <input type="radio" className="form-control" onChange={() => this.handleToggleGrantScope(user)} name="select-user" id={"select-user-" + user.username} checked={selected}/>
-      }
       var selected = (user.username===this.state.currentUser.username);
       userList.push(
         <li className={"list-group-item" + (selected?" active":"")} key={index}>
           <div className="row">
-            <div className="col">
-              <div className="input-group mb-3">
-                <div className="input-group-prepend">
-                  {inputUser}
-                </div>
-                <div className="btn-icon-right">
-                  <label className="form-check-label" htmlFor={"select-user-" + user.username}>{user.name||user.username}</label>
-                </div>
-              </div>
+            <div className="col" style={{paddingRight: "0"}}>
+              {inputUser}
             </div>
-            <div className="col text-right">
+            <div className="col-auto text-right" style={{paddingLeft: "0"}}>
               <button type="button" className="btn btn-secondary" onClick={() => this.handleLogoutAccount(user.username)}>{i18next.t("login.logout")}</button>
             </div>
           </div>

--- a/webapp-src/src/Profile/Navbar.js
+++ b/webapp-src/src/Profile/Navbar.js
@@ -108,7 +108,7 @@ class Navbar extends Component {
           });
         }
       });
-      document.location.href = this.state.config.LoginUrl + "?callback_url=" + encodeURIComponent([location.protocol, '//', location.host, location.pathname].join('')) + "&scope=" + encodeURIComponent(this.state.config.profile_scope) + (schemeDefault?("&scheme="+encodeURIComponent(schemeDefault)):"");
+      document.location.href = this.state.config.LoginUrl + "?callback_url=" + encodeURIComponent([location.protocol, '//', location.host, location.pathname].join('')) + "&scope=" + encodeURIComponent(this.state.config.profile_scope) + (schemeDefault?("&scheme="+encodeURIComponent(schemeDefault)):"") + "&prompt=login";
     }
   }
 

--- a/webapp-src/src/Profile/Navbar.js
+++ b/webapp-src/src/Profile/Navbar.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, useState, useEffect } from 'react';
 import i18next from 'i18next';
 
 import messageDispatcher from '../lib/MessageDispatcher';
@@ -116,6 +116,7 @@ class Navbar extends Component {
     var langList = [], schemeList = [], profileList = [], dataHighlight = "", completeAlert = "", complete = true;
     var profileDropdown, logoutButton;
     var passwordJsx, sessionJsx, profileJsx, userJsx;
+    var profilePicture;
     this.state.config.lang.forEach((lang, i) => {
       if (lang === i18next.language) {
         langList.push(<a className="dropdown-item active" href="#" key={i}>{lang}</a>);
@@ -159,11 +160,34 @@ class Navbar extends Component {
     }
     profileList.push(<div className="dropdown-divider" key={profileList.length}></div>);
     profileList.push(<a className="dropdown-item" href="#" onClick={(e) => this.changeProfile(e, null)} key={profileList.length}>{i18next.t("profile.menu-session-new")}</a>);
-    if (!this.state.config.params.register) {
-      profileDropdown = 
+    if (!this.state.config.params.register && this.state.profileList) {
+      if (this.state.config.profilePicture && this.state.profileList[0][this.state.config.profilePicture.property]) {
+        var picData = this.state.profileList[0][this.state.config.profilePicture.property];
+        if (Array.isArray(picData)) {
+          picData = picData[0];
+        }
+        profilePicture =
+        <div style={{whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis"}}>
+          <img className="img-medium" style={{maxWidth: "30px", maxHeight: "21px", objectFit: "scale-down"}} src={"data:*;base64,"+picData} />
+          &nbsp;
+        {this.state.profileList[0].username}
+        </div>
+      } else {
+        profilePicture =
+        <div style={{whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis"}}>
+          <img class="img-medium" style={{maxWidth: "1px"}} src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" /> {/*1-pixel transparent image as spacer (Possible Bootstrap bug)*/}
+          <i className="fas fa-user">
+            &nbsp;
+          </i>
+          {this.state.profileList[0].username}
+        </div>
+      }
+      profileDropdown =
       <div className="btn-group" role="group">
         <button className="btn btn-secondary dropdown-toggle" type="button" id="dropdownProfile" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          <i className="fas fa-user"></i>
+          <div style={{display: "block", float: "left"}}>
+            {profilePicture}
+          </div>
         </button>
         <div className="dropdown-menu" aria-labelledby="dropdownProfile">
           {profileList}
@@ -173,6 +197,11 @@ class Navbar extends Component {
         <button type="button" className="btn btn-secondary" onClick={this.toggleLogin} title={i18next.t((this.state.loggedIn?"title-logout":"title-login"))}>
           <i className="fas fa-sign-in-alt btn-icon"></i>
         </button>;
+    } else if (!this.state.config.params.register) {
+      logoutButton = 
+      <button type="button" className="btn btn-outline-primary" onClick={this.toggleLogin} title={i18next.t((this.state.loggedIn?"title-logout":"title-login"))}>
+        <i className="fas fa-sign-in-alt btn-icon"></i>
+      </button>;
     } else if (this.state.dataHighlight) {
       complete = false;
       dataHighlight = " required-field";


### PR DESCRIPTION
This is a PR in 5 thematic commits:

#### Navbar improvements

- To avoid duplication and clutter, the Add User button remains invisible until at least one user has been stored in the session.
- Navbars display the username and icon of the active user; the `fa-user` icon is used as placeholder if the user has not uploaded a picture.
- The above functionality is made reasonably responsive on small screens, with ellipses truncating the username whenever space is constrained.

#### Account selector improvements (Login => Manage logged-in users)

- Radio buttons are eliminated and replaced with a clickable "table" (in fact it's still a series of `<input>`s).
- Profile photos (or placeholders) are displayed alongside the full names.
- All bottom-row buttons are eliminated because they duplicate functions already on the screen ("New Account), or they do not work ("Grants"), or they make the workflow too labyrinthine for the user (IMO). The new screen is dedicated to a single function—fast user switching without mental friction (having to switch accounts is usually confusing and surprising enough in itself).

#### Login improvements

- An enlarged `fa-user` placeholder is used in the absence of an uploaded profile picture.
- Grant-related messages and buttons are replaced with a "no grants available" message if that is indeed the case.

#### Cosmetic tweaks (subjective)

- Login page content is centered for readability on small screens and quick identification of the most pertinent content ("Continue", "Log out").
- Buttons are colored to reflect their meaning and importance.
- Small things here and there.

