### PR TITLE
Navbar fixes

### DIFF
--- a/webapp-src/src/Admin/App.js
+++ b/webapp-src/src/Admin/App.js
@@ -102,10 +102,10 @@ class App extends Component {
         this.fetchApi();
       } else if (message.type === 'loggedIn') {
         this.setState({loggedIn: message.message}, () => {
-          console.log("loggedIn", this.state.loggedIn);
           if (!this.state.loggedIn) {
-            this.fetchApi();
+            this.setState({curNav: "users",profileList: this.state.profileList.filter((e,i) => i !== 0)});
           }
+          this.fetchApi();
         });
       } else if (message.type === 'lang') {
         this.setState({lang: i18next.language});

--- a/webapp-src/src/Admin/App.js
+++ b/webapp-src/src/Admin/App.js
@@ -101,10 +101,7 @@ class App extends Component {
       } else if (message.type === 'profile') {
         this.fetchApi();
       } else if (message.type === 'loggedIn') {
-        this.setState({loggedIn: message.message}, () => {
-          if (!this.state.loggedIn) {
-            this.setState({curNav: "users",profileList: this.state.profileList.filter((e,i) => i !== 0)});
-          }
+        this.setState({loggedIn: message.loggedIn}, () => {
           this.fetchApi();
         });
       } else if (message.type === 'lang') {
@@ -442,7 +439,8 @@ class App extends Component {
             modClients: [],
             modSchemes: [],
             plugins: [],
-            invalidCredentialMessage: true
+            invalidCredentialMessage: true,
+            profileList: []
           });
         });
       });
@@ -457,7 +455,8 @@ class App extends Component {
           modUsers: [],
           modClients: [],
           modSchemes: [],
-          plugins: []
+          plugins: [],
+          profileList: []
         }, () => {
           if (error.status === 401) {
             messageDispatcher.sendMessage('Notification', {type: "danger", message: i18next.t("admin.requires-admin-scope")});

--- a/webapp-src/src/Admin/Navbar.js
+++ b/webapp-src/src/Admin/Navbar.js
@@ -112,7 +112,7 @@ class Navbar extends Component {
     }
     profileList.push(<div className="dropdown-divider" key={profileList.length}></div>);
     profileList.push(<a className="dropdown-item" href="#" onClick={(e) => this.changeProfile(e, null)} key={profileList.length}>{i18next.t("profile.menu-session-new")}</a>);
-    if (this.state.profileList) {
+    if (this.state.profileList && this.state.profileList[0]) {
       if (this.state.config.profilePicture && this.state.profileList[0][this.state.config.profilePicture.property]) {
         var picData = this.state.profileList[0][this.state.config.profilePicture.property];
         if (Array.isArray(picData)) {

--- a/webapp-src/src/Profile/App.js
+++ b/webapp-src/src/Profile/App.js
@@ -62,11 +62,7 @@ class App extends Component {
           this.setState({curNav: message.module, module: message.page});
         }
       } else if (message.type === 'loggedIn') {
-        this.setState({loggedIn: message.message}, () => {
-          if (!this.state.loggedIn) {
-            // Not sure about `schemeList` in the line below!
-            this.setState({curNav: "profile", profileList: this.state.profileList.filter((e,i) => i !== 0), schemeList: []});
-          }
+        this.setState({loggedIn: message.loggedIn}, () => {
           this.fetchProfile();
         });
       } else if (message.type === 'lang') {

--- a/webapp-src/src/Profile/App.js
+++ b/webapp-src/src/Profile/App.js
@@ -64,10 +64,10 @@ class App extends Component {
       } else if (message.type === 'loggedIn') {
         this.setState({loggedIn: message.message}, () => {
           if (!this.state.loggedIn) {
-            this.setState({profileList: false, schemeList: [], curNav: "profile"});
-          } else {
-            this.fetchProfile();
+            // Not sure about `schemeList` in the line below!
+            this.setState({curNav: "profile", profileList: this.state.profileList.filter((e,i) => i !== 0), schemeList: []});
           }
+          this.fetchProfile();
         });
       } else if (message.type === 'lang') {
         this.setState({lang: i18next.language}, () => {

--- a/webapp-src/src/Profile/Navbar.js
+++ b/webapp-src/src/Profile/Navbar.js
@@ -160,7 +160,7 @@ class Navbar extends Component {
     }
     profileList.push(<div className="dropdown-divider" key={profileList.length}></div>);
     profileList.push(<a className="dropdown-item" href="#" onClick={(e) => this.changeProfile(e, null)} key={profileList.length}>{i18next.t("profile.menu-session-new")}</a>);
-    if (!this.state.config.params.register && this.state.profileList) {
+    if (!this.state.config.params.register && this.state.profileList && this.state.profileList[0]) {
       if (this.state.config.profilePicture && this.state.profileList[0][this.state.config.profilePicture.property]) {
         var picData = this.state.profileList[0][this.state.config.profilePicture.property];
         if (Array.isArray(picData)) {
@@ -176,6 +176,7 @@ class Navbar extends Component {
         <div className="glwd-nav-picture-div">
           <img className="img-medium glwd-nav-picture-spacer" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" /> {/*1-pixel transparent image as spacer (Possible Bootstrap bug)*/}
           <i className="fas fa-user">
+            &nbsp;
           </i>
           {this.state.profileList[0].username}
         </div>
@@ -193,12 +194,12 @@ class Navbar extends Component {
       </div>;
       logoutButton = 
         <button type="button" className="btn btn-secondary" onClick={this.toggleLogin} title={i18next.t((this.state.loggedIn?"title-logout":"title-login"))}>
-          <i className="fas fa-sign-in-alt btn-icon"></i>
+          {this.state.loggedIn ? <i className="fas fa-sign-out-alt btn-icon"></i> : <i className="fas fa-sign-in-alt btn-icon"></i>}
         </button>;
     } else if (!this.state.config.params.register) {
       logoutButton = 
       <button type="button" className="btn btn-secondary" onClick={this.toggleLogin} title={i18next.t((this.state.loggedIn?"title-logout":"title-login"))}>
-        <i className="fas fa-sign-in-alt btn-icon"></i>
+        {this.state.loggedIn ? <i className="fas fa-sign-out-alt btn-icon"></i> : <i className="fas fa-sign-in-alt btn-icon"></i>}
       </button>;
     } else if (this.state.dataHighlight) {
       complete = false;


### PR DESCRIPTION
The list of users in the two navigation bars (Admin and Profile) is not always synchronized with the actual list of users if two or more users are active. This PR fixes the issue.

The fix consists of two parts. First, only the currently active user is removed from `profileList[]` (I am avoiding `slice()` for this purpose because it is considered bad ReactJS practice on array-like states). Second, `this.fetchAPI()` is no longer called if a user has just logged out.

An edge case producing a crash is also fixed by ensuring that `this.state.profileList[0]` exist before attempting to index it.

To test, please log in with at least two usernames, then log them out one by one, each time noticing the effects on the navigation bar dropdowns. 
