### PR TITLE
Red Log Out button fix.

### DIFF
--- a/webapp-src/src/Login/Buttons.js
+++ b/webapp-src/src/Login/Buttons.js
@@ -50,7 +50,7 @@ class Buttons extends Component {
   }
 
   clickLogout() {
-    apiManager.glewlwydRequest("/auth/", "DELETE")
+    apiManager.glewlwydRequest("/auth/?username=" + this.state.currentUser.username, "DELETE")
     .then(() => {
       messageDispatcher.sendMessage('App', {type: 'InitProfile'});
     })


### PR DESCRIPTION
By analogy to its adjacent Continue button, the red Log Out button should only act on the current user.