### PR TITLE
Implement grant-none-available as in #136

### DIFF
--- a/webapp-src/locales/en/translations.json
+++ b/webapp-src/locales/en/translations.json
@@ -44,6 +44,7 @@
     "error-value-expected": "Value required",
     "grant-title": "{{- client}} requires access to the following scopes",
     "grant": "Grant access",
+    "grant-none-available": "No grants have been requested",
     "grant-change-title": "Change grant scope for client",
     "grant-change": "Grant",
     "grant-auth-title": "Authenticate all access for the client",

--- a/webapp-src/locales/fr/translations.json
+++ b/webapp-src/locales/fr/translations.json
@@ -44,6 +44,7 @@
     "error-value-expected": "Valeur requise",
     "grant-title": "{{- client}} demande les droits d'accès suivants",
     "grant": "Autoriser l'accès",
+    "grant-none-available": "Aucune demande n'a été faite pour des droits d'accès",
     "grant-change-title": "Changer l'accès aux droits pour le client",
     "grant-change": "Droit d'accès",
     "grant-auth-title": "Autoriser tous les accès pour le client",

--- a/webapp-src/src/Login/GrantScope.js
+++ b/webapp-src/src/Login/GrantScope.js
@@ -88,41 +88,50 @@ class GrantScope extends Component {
     if (this.state.infoSomeScopeUnavailable) {
       infoSomeScopeUnavailable = <div className="alert alert-info" role="alert">{i18next.t("login.info-some-scope-unavailable")}</div>
     }
-    return (
-    <div>
-      <div className="row">
-        <div className="col-md-12">
-          <h5>{i18next.t("login.grant-title", {client: this.state.client.name})}</h5>
+    if (this.state.scope.length) {
+      return (
+      <div>
+        <div className="row">
+          <div className="col-md-12">
+            <h5>{i18next.t("login.grant-title", {client: this.state.client.name})}</h5>
+          </div>
         </div>
-      </div>
-      <div className="row">
-        <div className="col-md-12">
-          <ul className="list-group">
-            {scopeList}
-          </ul>
+        <div className="row">
+          <div className="col-md-12">
+            <ul className="list-group">
+              {scopeList}
+            </ul>
+          </div>
         </div>
-      </div>
-      <div className="row">
-        <div className="col-md-12">
-          {infoSomeScopeUnavailable}
+        <div className="row">
+          <div className="col-md-12">
+            {infoSomeScopeUnavailable}
+          </div>
         </div>
-      </div>
-      <div className="row">
-        <div className="col-md-12">
-          <button type="button" className="btn btn-primary" onClick={this.handleGrantScope}>{i18next.t("login.grant")}</button>
+        <div className="row">
+          <div className="col-md-12">
+            <button type="button" className="btn btn-primary" onClick={this.handleGrantScope}>{i18next.t("login.grant")}</button>
+          </div>
         </div>
-      </div>
-      <hr className="glwd-hr-no-border"/>
-      <div className="row">
-        <div className="col-md-12">
-          <b>
-            {i18next.t("login.grant-info-message")}
-          </b>
+        <hr className="glwd-hr-no-border"/>
+        <div className="row">
+          <div className="col-md-12">
+            <b>
+              {i18next.t("login.grant-info-message")}
+            </b>
+          </div>
         </div>
-      </div>
-    </div>);
+      </div>);
+    } else {
+      return (
+        <div className="row">
+          <div className="col-md-12">
+            <h5>{i18next.t("login.grant-none-available")}</h5>
+          </div>
+        </div>
+      );
+    }
   }
-
 }
 
 export default GrantScope;


### PR DESCRIPTION
Hello @yrammos ,

I've reapplied your commit [Grant selection improvement](https://github.com/babelouest/glewlwyd/pull/136/commits/9175a554c2aa0db996051ac832164b7945f490d4) from PR #136 . I still can't see where this change could be accessible in the UI.

- If the connected user has access to at least one of the required scopes, she/he can grant the client access to one or more of the scopes (normal behavior)
![grant scopes](https://user-images.githubusercontent.com/3966617/84969148-189b0280-b0e6-11ea-8a9c-d9a2ee4ef2ff.png)

- If the connected user has access to none of the required scopes, she/he won't even be able to access to the grant select, the login page tells the user she/he has not the required access
![grant no scope](https://user-images.githubusercontent.com/3966617/84969201-336d7700-b0e6-11ea-8cc9-0e30ef41cf7e.png)

The only way I found to display the message is to manually change the url and set an empty scope parameter: `login.html?client_id=client1_id&scope=&callback_url=http...`
![no scope](https://user-images.githubusercontent.com/3966617/84969310-66176f80-b0e6-11ea-9843-55138469694e.png)

The problem with this 3rd option is that it's impossible for a user to require an access without scopes. Even if the OAuth2/OIDC specs say it should be possible to get an access_token without scope, I chose to avoid that and made the scope parameter mandatory.
It was possible in Glewlwyd 1.x to authenticate without scopes but it lead to some edge cases and made the application more complex. So I dropped this feature in the next version.

I may have misunderstood what you wanted to fix or implement though. If so, can you help me understand?