### PR TITLE
Login form buttonwear

### DIFF
--- a/webapp-src/src/Login/App.js
+++ b/webapp-src/src/Login/App.js
@@ -273,9 +273,9 @@ class App extends Component {
           } else {
             if ((this.state.newUser || this.state.passwordRequired)) {
               if (!this.state.scheme) {
-                body = <PasswordForm config={this.state.config} username={this.state.login_hint} currentUser={this.state.currentUser} callbackInitProfile={this.initProfile}/>;
+                body = <PasswordForm config={this.state.config} username={this.state.login_hint} currentUser={this.state.currentUser} userList={this.state.userList} callbackInitProfile={this.initProfile}/>;
               } else {
-                body = <NoPasswordForm config={this.state.config} username={this.state.login_hint} callbackInitProfile={this.initProfile} scheme={this.state.scheme}/>;
+                body = <NoPasswordForm config={this.state.config} username={this.state.login_hint} userList={this.state.userList} callbackInitProfile={this.initProfile} scheme={this.state.scheme}/>;
               }
             } else if (this.state.selectAccount) {
               body = <SelectAccount config={this.state.config} userList={this.state.userList} currentUser={this.state.currentUser}/>;

--- a/webapp-src/src/Login/NoPasswordForm.js
+++ b/webapp-src/src/Login/NoPasswordForm.js
@@ -73,7 +73,7 @@ class NoPasswordForm extends Component {
           </div>
           <div className="row">
             <div className="col-md-3">
-              <button type="submit" name="usernamebut" id="usernamebut" className="btn btn-primary" onClick={(e) => this.validateUsername(e)} title={i18next.t("login.sign-in-title")}>{i18next.t("login.btn-ok")}</button>
+              <button type="submit" name="usernamebut" id="usernamebut" className="btn btn-primary btn-lg btn-block" onClick={(e) => this.validateUsername(e)} title={i18next.t("login.sign-in-title")}>{i18next.t("login.btn-ok")}</button>
             </div>
             <div className="col-md-9 text-right mt-2">
               {manageUsersButton}

--- a/webapp-src/src/Login/NoPasswordForm.js
+++ b/webapp-src/src/Login/NoPasswordForm.js
@@ -19,7 +19,8 @@ class NoPasswordForm extends Component {
       config: props.config,
       username: props.username,
       usernameValidated: false,
-      scheme: props.scheme
+      scheme: props.scheme,
+      userList: props.userList
     };
 
     this.handleChangeUsername = this.handleChangeUsername.bind(this);
@@ -30,7 +31,8 @@ class NoPasswordForm extends Component {
     this.setState({
       config: nextProps.config,
       username: nextProps.username,
-      scheme: nextProps.scheme
+      scheme: nextProps.scheme,
+      userList: nextProps.userList
     });
   }
 
@@ -45,7 +47,16 @@ class NoPasswordForm extends Component {
     }
   }
 
+  gotoManageUsers(e) {
+    e.preventDefault();
+    document.location.href = this.state.config.LoginUrl + "?callback_url=" + encodeURIComponent([location.protocol, '//', location.host, location.pathname].join('')) + "&scope=" + encodeURIComponent(this.state.config.profile_scope) + "&prompt=select_account";  
+  }
+
 	render() {
+    var manageUsersButton;
+    if (this.state.userList.length > 0) {
+      manageUsersButton = <button type="button" className="btn btn-secondary" onClick={(e) => this.gotoManageUsers(e)}>{i18next.t("login.manage-users")}</button>
+    }
     if (!this.state.usernameValidated) {
       return (
         <form action="#" id="passwordForm">
@@ -60,7 +71,14 @@ class NoPasswordForm extends Component {
               <input type="text" className="form-control" name="username" id="username" autoFocus={true} required="" placeholder={i18next.t("login.login-placeholder")} value={this.state.username} onChange={this.handleChangeUsername} autoFocus/>
             </div>
           </div>
-          <button type="submit" name="usernamebut" id="usernamebut" className="btn btn-primary" onClick={(e) => this.validateUsername(e)} title={i18next.t("login.sign-in-title")}>{i18next.t("login.btn-ok")}</button>
+          <div className="row">
+            <div className="col-md-3">
+              <button type="submit" name="usernamebut" id="usernamebut" className="btn btn-primary" onClick={(e) => this.validateUsername(e)} title={i18next.t("login.sign-in-title")}>{i18next.t("login.btn-ok")}</button>
+            </div>
+            <div className="col-md-9 text-right mt-2">
+              {manageUsersButton}
+            </div>
+          </div>
         </form>
       );
     } else {
@@ -95,6 +113,11 @@ class NoPasswordForm extends Component {
             {curScheme}
           </div>
           <div className="form-group">
+            <div className="row">
+              <div className="col-md-12 text-right mt-2">
+                {manageUsersButton}
+              </div>
+            </div>
           </div>
         </div>
       );

--- a/webapp-src/src/Login/PasswordForm.js
+++ b/webapp-src/src/Login/PasswordForm.js
@@ -12,7 +12,8 @@ class PasswordForm extends Component {
       username: props.username,
       password: "",
       config: props.config,
-      currentUser: props.currentUser
+      currentUser: props.currentUser,
+      userList: props.userList
     };
 
     this.handleChangeUsername = this.handleChangeUsername.bind(this);
@@ -25,7 +26,8 @@ class PasswordForm extends Component {
       username: nextProps.username,
       password: "",
       config: nextProps.config,
-      currentUser: nextProps.currentUser
+      currentUser: nextProps.currentUser,
+      userList: nextProps.userList
     });
   }
   
@@ -55,12 +57,20 @@ class PasswordForm extends Component {
     }
   }
 
+  gotoManageUsers(e) {
+    e.preventDefault();
+    document.location.href = this.state.config.LoginUrl + "?callback_url=" + encodeURIComponent([location.protocol, '//', location.host, location.pathname].join('')) + "&scope=" + encodeURIComponent(this.state.config.profile_scope) + "&prompt=select_account";  
+  }
+
 	render() {
-    var inputUsername;
+    var inputUsername, manageUsersButton;
     if (this.state.currentUser) {
       inputUsername = <input type="text" className="form-control" name="username" id="username" disabled={true} value={this.state.currentUser.username} />
     } else {
       inputUsername = <input type="text" className="form-control" name="username" id="username" required="" placeholder={i18next.t("login.login-placeholder")} value={this.state.username} onChange={this.handleChangeUsername} autoFocus={true}/>;
+    }
+    if (this.state.userList.length > 0) {
+      manageUsersButton = <button type="button" className="btn btn-secondary" onClick={(e) => this.gotoManageUsers(e)}>{i18next.t("login.manage-users")}</button>
     }
 		return (
       <form action="#" id="passwordForm">
@@ -83,7 +93,14 @@ class PasswordForm extends Component {
             <input type="password" className="form-control" name="password" id="password" required="" placeholder={i18next.t("login.password-placeholder")} value={this.state.password} onChange={this.handleChangePassword} autoFocus={!!this.state.currentUser}/>
           </div>
         </div>
-        <button type="submit" name="loginbut" id="loginbut" className="btn btn-primary" onClick={(e) => this.validateLogin(e)} title={i18next.t("login.sign-in-title")}>{i18next.t("login.btn-ok")}</button>
+        <div className="row">
+          <div className="col-md-3">
+              <button type="submit" name="loginbut" id="loginbut" className="btn btn-primary btn-lg btn-block" onClick={(e) => this.validateLogin(e)} title={i18next.t("login.sign-in-title")}>{i18next.t("login.btn-ok")}</button>
+          </div>
+          <div className="col-md-9 text-right mt-2">
+            {manageUsersButton}
+          </div>
+        </div>
       </form>
 		);
 	}


### PR DESCRIPTION
Includes button to Manage Connected Users in the login form, if such users indeed exist in the session.

Also enlarges the OK button on the username/password login form. This is a proof of concept; a future PR should probably address button sizing throughout the app, because default action buttons (e.g. OK) are too often smaller than their non-default counterparts (e.g. CLOSE).

Follows up from https://github.com/babelouest/glewlwyd/pull/140#issuecomment-645543443. 