### PR TITLE
Clear state upon logging out.

### DIFF
--- a/webapp-src/locales/en/translations.json
+++ b/webapp-src/locales/en/translations.json
@@ -112,7 +112,9 @@
     "device-auth-user-code-ph": "X1Y2-A3B4",
     "device-authorization-complete-message": "Authorization complete, you may close this window",
     "device-authorization-server-error-message": "Server error",
-    "device-authorization-code-error-message": "Invalid code, please retry"
+    "device-authorization-code-error-message": "Invalid code, please retry",
+    "session-closed-title": "Session closed",
+    "session-closed-message": "You are disconnected"
   },
   "admin": {
     "error-credential-message": "Please connect with a user that has admin credentials",

--- a/webapp-src/locales/fr/translations.json
+++ b/webapp-src/locales/fr/translations.json
@@ -112,7 +112,9 @@
     "device-auth-user-code-ph": "X1Y2-A3B4",
     "device-authorization-complete-message": "Autorisation complète, vous pouvez fermer cette fenêtre",
     "device-authorization-server-error-message": "Erreur du serveur",
-    "device-authorization-code-error-message": "Code invalide, veuillez réssayer"
+    "device-authorization-code-error-message": "Code invalide, veuillez réssayer",
+    "session-closed-title": "Session fermée",
+    "session-closed-message": "Vous n'êtes plus connecté"
   },
   "admin": {
     "error-credential-message": "Veuillez vous conncecter avec un utilisateur ayant les droits d'administration",

--- a/webapp-src/src/Login/App.js
+++ b/webapp-src/src/Login/App.js
@@ -10,6 +10,7 @@ import PasswordForm from './PasswordForm';
 import NoPasswordForm from './NoPasswordForm';
 import SelectAccount from './SelectAccount';
 import EndSession from './EndSession';
+import SessionClosed from './SessionClosed';
 import DeviceAuth from './DeviceAuth';
 
 class App extends Component {
@@ -36,6 +37,7 @@ class App extends Component {
       forceShowGrant: false,
       selectAccount: false,
       endSession: false,
+      sessionClosed: false,
       deviceAuth: false,
       login_hint: props.config.params.login_hint||"",
       errorScopesUnavailable: false,
@@ -79,6 +81,8 @@ class App extends Component {
         this.setState({showGrant: !this.state.showGrant});
       } else if (message.type === "newUserScheme") {
         this.setState({scheme: message.scheme});
+      } else if (message.type === "SessionClosed") {
+        this.setState({endSession: false, sessionClosed: true});
       }
     });
   }
@@ -102,6 +106,7 @@ class App extends Component {
         newState.selectAccount = true;
       } else if (this.state.prompt === "end_session") {
         newState.endSession = true;
+        newState.sessionClosed = false;
         newState.newUser = false;
         newState.currentUser = false;
       } else if (this.state.prompt && this.state.prompt.substring(0, 6) === "device") {
@@ -258,6 +263,8 @@ class App extends Component {
       if (this.state.loaded) {
         if (this.state.endSession) {
           body = <EndSession config={this.state.config} userList={this.state.userList} currentUser={this.state.currentUser}/>;
+        } else if (this.state.sessionClosed) {
+          body = <SessionClosed config={this.state.config}/>;
         } else if (this.state.deviceAuth) {
           body = <DeviceAuth config={this.state.config} userList={this.state.userList} currentUser={this.state.currentUser}/>;
         } else {

--- a/webapp-src/src/Login/EndSession.js
+++ b/webapp-src/src/Login/EndSession.js
@@ -34,6 +34,8 @@ class EndSession extends Component {
     .always(() => {
       if (this.state.config.params.callback_url) {
         document.location.href = this.state.config.params.callback_url;
+      } else {
+        messageDispatcher.sendMessage('App', {type: 'SessionClosed'});
       }
     });
   }

--- a/webapp-src/src/Login/SelectAccount.js
+++ b/webapp-src/src/Login/SelectAccount.js
@@ -61,7 +61,7 @@ class SelectAccount extends Component {
   handleLogoutAll() {
     apiManager.glewlwydRequest("/auth/", "DELETE")
     .then(() => {
-      messageDispatcher.sendMessage('App', {type: 'InitProfile'});
+      messageDispatcher.sendMessage('App', {type: 'SessionClosed'});
     })
     .fail(() => {
       messageDispatcher.sendMessage('Notification', {type: "danger", message: i18next.t("login.error-login")});

--- a/webapp-src/src/Login/SessionClosed.js
+++ b/webapp-src/src/Login/SessionClosed.js
@@ -1,0 +1,32 @@
+import React, { Component } from 'react';
+import i18next from 'i18next';
+
+import messageDispatcher from '../lib/MessageDispatcher';
+
+class SessionClosed extends Component {
+  constructor(props) {
+    super(props);
+    
+    this.state = {
+      config: props.config
+    };
+  }
+  
+  render() {
+    return (
+    <div>
+      <div className="row">
+        <div className="col-md-12">
+          <h3>{i18next.t("login.session-closed-title")}</h3>
+        </div>
+      </div>
+      <div className="row">
+        <div className="col-md-12">
+          <h4>{i18next.t("login.session-closed-message")}</h4>
+        </div>
+      </div>
+    </div>);
+  }
+}
+
+export default SessionClosed;

--- a/webapp-src/src/Profile/Password.js
+++ b/webapp-src/src/Profile/Password.js
@@ -18,7 +18,8 @@ class Password extends Component {
       password_confirm: "",
       oldPasswordInvalid: false,
       passwordInvalid: false,
-      passwordConfirmInvalid: false
+      passwordConfirmInvalid: false,
+      loggedIn: false
     }
     
     this.passwordButtonHandler = this.passwordButtonHandler.bind(this);
@@ -32,7 +33,17 @@ class Password extends Component {
     this.setState({
       config: nextProps.config,
       passwordMinLength: nextProps.config.PasswordMinLength||8,
-      callback: nextProps.callback
+      callback: nextProps.callback,
+      loggedIn: nextProps.loggedIn
+    }, () => {
+      if (!this.state.loggedIn) {
+        this.setState({
+          password: '',
+          old_password: '',
+          password_confirm: '',
+          passwordMinLength: 0
+        });
+      };
     });
   }
   

--- a/webapp-src/src/Profile/Session.js
+++ b/webapp-src/src/Profile/Session.js
@@ -44,6 +44,12 @@ class Session extends Component {
       if (this.state.profile) {
         this.fetchLists();
       }
+      if (!this.state.loggedIn) {
+        this.setState({
+          profile: [],
+          sessionList: []
+        });
+      };
     });
   }
   
@@ -83,6 +89,8 @@ class Session extends Component {
       .fail(() => {
         messageDispatcher.sendMessage('Notification', {type: "danger", message: i18next.t("error-api-connect")});
       });
+    } else {
+      this.setState({sessionList: []});
     }
   }
   

--- a/webapp-src/src/Profile/User.js
+++ b/webapp-src/src/Profile/User.js
@@ -49,6 +49,13 @@ class User extends Component {
       listAddValue: this.initListAdd(nextProps.pattern),
       listEltConfirm: this.initListConfirm(nextProps.pattern),
       listError: {}
+    }, () => {
+      if (!this.state.loggedIn) {
+        this.setState({
+          pattern: [],
+          profile: []
+        });
+      };
     });
   }
   


### PR DESCRIPTION
@babelouest I'm submitting this PR tentatively—feel free to close, delete, or continue the discussion via a private channel.

A proper log-out view is in the works, as we both know, and this will eliminate once and for all the possibility of private data remaining visible on the screen after logging out.

From a security point of view, though, hiding things from view is likely not enough. An intuitively and formally trustworthy pattern for deleting all potentially private data from `this.state` would provide additional piece of mind. I think a Redux developer (which I'm not) would use "reducers" [for doing this reliably](https://netbasal.com/how-to-secure-your-users-data-after-logout-in-redux-30468c6848e8). 

In a typical React pattern, where statefulness is tightly controlled, this is not difficult to do. Yet state ownership in Glewlwyd is distributed among components. So each component should probably provide reasonable "proof" that it has cleaned after itself whenever a user logs out. I realize that this is mostly done already—mostly, but not always, and sometimes it is hard to tell (e.g. with schemes/plugins).

The PR is meant to raise the issue. It proposes that `componentWillReceiveProps()` *might* (?) be a suitable place for zeroing-out state values in an accountable way ("accountable" in the sense that any state values not reset within `componentWillReceiveProps` may not be safely assumed reset upon logging out).

In the longer run, one would probably take measures against browser caching and "forward-backward" browser navigation, e.g. by using React Router.