### PR TITLE
Clear visible state upon logging out (back-porting #144)

### DIFF
--- a/webapp-src/src/Profile/Password.js
+++ b/webapp-src/src/Profile/Password.js
@@ -18,7 +18,8 @@ class Password extends Component {
       password_confirm: "",
       oldPasswordInvalid: false,
       passwordInvalid: false,
-      passwordConfirmInvalid: false
+      passwordConfirmInvalid: false,
+      loggedIn: false
     }
     
     this.passwordButtonHandler = this.passwordButtonHandler.bind(this);
@@ -32,7 +33,17 @@ class Password extends Component {
     this.setState({
       config: nextProps.config,
       passwordMinLength: nextProps.config.PasswordMinLength||8,
-      callback: nextProps.callback
+      callback: nextProps.callback,
+      loggedIn: nextProps.loggedIn
+    }, () => {
+      if (!this.state.loggedIn) {
+        this.setState({
+          password: '',
+          old_password: '',
+          password_confirm: '',
+          passwordMinLength: 0
+        });
+      };
     });
   }
   

--- a/webapp-src/src/Profile/Session.js
+++ b/webapp-src/src/Profile/Session.js
@@ -44,6 +44,12 @@ class Session extends Component {
       if (this.state.profile) {
         this.fetchLists();
       }
+      if (!this.state.loggedIn) {
+        this.setState({
+          profile: [],
+          sessionList: []
+        });
+      };
     });
   }
   
@@ -83,6 +89,8 @@ class Session extends Component {
       .fail(() => {
         messageDispatcher.sendMessage('Notification', {type: "danger", message: i18next.t("error-api-connect")});
       });
+    } else {
+      this.setState({sessionList: []});
     }
   }
   

--- a/webapp-src/src/Profile/User.js
+++ b/webapp-src/src/Profile/User.js
@@ -49,6 +49,13 @@ class User extends Component {
       listAddValue: this.initListAdd(nextProps.pattern),
       listEltConfirm: this.initListConfirm(nextProps.pattern),
       listError: {}
+    }, () => {
+      if (!this.state.loggedIn) {
+        this.setState({
+          pattern: [],
+          profile: []
+        });
+      };
     });
   }
   


### PR DESCRIPTION
Backporting #144 onto this branch. 

@babelouest this is probably not a complete fix. The intention is to make a case for a uniform, application-wide pattern for purging sensitive `this.state` values on log out. Thanks as ever.