### PR TITLE
No CSS pointer events for greyed-out navbar items.

### DIFF
--- a/webapp-src/css/glewlwyd.css
+++ b/webapp-src/css/glewlwyd.css
@@ -142,4 +142,5 @@
 .glwd-nav-user-unavailable, .glwd-nav-user-unavailable:hover, .glwd-nav-user-unavailable:focus {
   cursor: default;
   color: #dcdcdc;
+  pointer-events: none;
 }


### PR DESCRIPTION
@babelouest, just a tiny tweak in a moment of pixel-level obsession.  Thanks.