### PR TITLE
Remove explicit "Authorization" header

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -826,13 +826,12 @@ The following example is an Nginx reverse proxy configuration in which the glewl
 ```
 # Glewlwyd
     location / {
-        proxy_set_header Authorization $http_authorization;
         proxy_set_header Host $host;
         proxy_pass http://127.0.0.1:4593;
     }
 ```
 
-By default, Nginx will only pass headers to a proxy service that are present in the *initial* request of a session. The glewlwyd admin web app uses Authorization headers *after* a user is logged in to maintain the user's session as the user navigates the application from page to page. Therefore, to make sure Nginx passes the Authorization header on all requests it must be explicitly declared in the proxy configuration.  Other headers which may be useful to define as `proxy_set_header` options here are `X-Forwarded-For` and/or `X-Real-IP`, to pass along the requesting client's IP rather than the proxy IP for logging purposes.  See [the Nginx proxy docs](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_set_header) for further information.
+Other headers which may be useful to define as `proxy_set_header` options here besides `Host` are `X-Forwarded-For` and/or `X-Real-IP`, to pass along the requesting client's IP rather than the proxy IP for logging purposes.  See [the Nginx proxy docs](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_set_header) for further information.
 
 It is also possible to use Nginx to serve glewlwyd from a subfolder, which would allow multiple services to share a single proxy listening for requests on a single domain name. Below is an example configuration for doing this with Nginx.
 
@@ -840,7 +839,6 @@ It is also possible to use Nginx to serve glewlwyd from a subfolder, which would
 # Glewlwyd
     location ^~ /authsrv/ {
         rewrite ^\/authsrv(.*) /$1 break;
-        proxy_set_header Authorization $http_authorization;
         proxy_set_header Host $host;
         proxy_pass http://127.0.0.1:4593;
     }


### PR DESCRIPTION
Previously included explicit declaration of `Authorization` header based on #32 . Tested with Oauth2 plugin against a Postgrest API with Postman as a client, and the explicit `Authorization` header/variable are not necessary on Nginx 1.18.0, running on Ubuntu 20.04. I was able to POST and PATCH with the returned token just fine without explicit declaration of the `Authorization` header in the Nginx config.