### PR TITLE
Fix LDAP group mapping (scope correspondence in LDAP user/client module)

### DIFF
--- a/src/client/ldap.c
+++ b/src/client/ldap.c
@@ -107,7 +107,7 @@ static json_t * is_client_ldap_parameters_valid(json_t * j_params, int readonly)
       if (json_object_get(j_params, "scope-match") != NULL && !json_is_array(json_object_get(j_params, "scope-match"))) {
         json_array_append_new(j_error, json_string("scope-match is optional and must be a JSON array"));
       } else if (json_object_get(j_params, "scope-match") != NULL) {
-        json_array_foreach(json_object_get(j_params, "scope-property-match-correspondence"), index, j_element) {
+        json_array_foreach(json_object_get(j_params, "scope-match"), index, j_element) {
           if (!json_is_string(json_object_get(j_element, "ldap-value"))) {
             json_array_append_new(j_error, json_string("ldap-value is mandatory and must be a string"));
           }
@@ -912,16 +912,19 @@ static LDAPMod ** get_ldap_write_mod(json_t * j_params, json_t * j_client, int a
 
 static json_t * get_scope_from_ldap(json_t * j_params, const char * ldap_scope_value) {
   json_t * j_element = NULL;
-  const char * key = NULL, * value;
-  
-  if (json_object_get(j_params, "scope-property-match-correspondence") != NULL) {
-    json_object_foreach(json_object_get(j_params, "scope-property-match-correspondence"), key, j_element) {
-      value = json_string_value(j_element);
-      if ((0 == o_strcmp("equals", json_string_value(json_object_get(j_params, "scope-property-match"))) && 0 == o_strcmp(value, ldap_scope_value)) ||
-          (0 == o_strcmp("contains", json_string_value(json_object_get(j_params, "scope-property-match"))) && NULL != o_strstr(ldap_scope_value, value)) ||
-          (0 == o_strcmp("starts-with", json_string_value(json_object_get(j_params, "scope-property-match"))) && 0 != o_strncmp(ldap_scope_value, value, o_strlen(value))) ||
-          (0 == o_strcmp("ends-with", json_string_value(json_object_get(j_params, "scope-property-match"))) && 0 != strcmp(ldap_scope_value + o_strlen(ldap_scope_value) - o_strlen(value), value))) {
-        return json_string(key);
+  size_t index = 0;
+  const char * value, * scope, * match;
+
+  if (json_object_get(j_params, "scope-match") != NULL) {
+    json_array_foreach(json_object_get(j_params, "scope-match"), index, j_element) {
+      value = json_string_value(json_object_get(j_element, "ldap-value"));
+      scope = json_string_value(json_object_get(j_element, "scope-value"));
+      match = json_string_value(json_object_get(j_element, "match"));
+      if ((0 == o_strcmp("equals", match) && 0 == o_strcmp(value, ldap_scope_value)) ||
+          (0 == o_strcmp("contains", match) && NULL != o_strstr(ldap_scope_value, value)) ||
+          (0 == o_strcmp("starts-with", match) && 0 != o_strncmp(ldap_scope_value, value, o_strlen(value))) ||
+          (0 == o_strcmp("ends-with", match) && 0 != strcmp(ldap_scope_value + o_strlen(ldap_scope_value) - o_strlen(value), value))) {
+        return json_string(scope);
       }
     }
   }

--- a/src/client/ldap.c
+++ b/src/client/ldap.c
@@ -114,7 +114,7 @@ static json_t * is_client_ldap_parameters_valid(json_t * j_params, int readonly)
           if (!json_is_string(json_object_get(j_element, "scope-value"))) {
             json_array_append_new(j_error, json_string("scope-value is mandatory and must be a string"));
           }
-          if (!json_is_string(json_object_get(j_element, "match")) || 0 != o_strcmp("equals", json_string_value(json_object_get(j_element, "match"))) || 0 != o_strcmp("contains", json_string_value(json_object_get(j_element, "match"))) || 0 != o_strcmp("startswith", json_string_value(json_object_get(j_element, "match"))) || 0 != o_strcmp("endswith", json_string_value(json_object_get(j_element, "match")))) {
+          if (!json_is_string(json_object_get(j_element, "match")) || (0 != o_strcmp("equals", json_string_value(json_object_get(j_element, "match"))) && 0 != o_strcmp("contains", json_string_value(json_object_get(j_element, "match"))) && 0 != o_strcmp("startswith", json_string_value(json_object_get(j_element, "match"))) && 0 != o_strcmp("endswith", json_string_value(json_object_get(j_element, "match"))))) {
             json_array_append_new(j_error, json_string("match is mandatory and must have one of the following values: 'equals', 'contains', 'startswith', 'endswith'"));
           }
         }

--- a/src/user/ldap.c
+++ b/src/user/ldap.c
@@ -177,7 +177,7 @@ static json_t * is_user_ldap_parameters_valid(json_t * j_params, int readonly) {
           if (!json_is_string(json_object_get(j_element, "scope-value"))) {
             json_array_append_new(j_error, json_string("scope-value is mandatory and must be a string"));
           }
-          if (!json_is_string(json_object_get(j_element, "match")) || 0 != o_strcmp("equals", json_string_value(json_object_get(j_element, "match"))) || 0 != o_strcmp("contains", json_string_value(json_object_get(j_element, "match"))) || 0 != o_strcmp("startswith", json_string_value(json_object_get(j_element, "match"))) || 0 != o_strcmp("endswith", json_string_value(json_object_get(j_element, "match")))) {
+          if (!json_is_string(json_object_get(j_element, "match")) || (0 != o_strcmp("equals", json_string_value(json_object_get(j_element, "match"))) && 0 != o_strcmp("contains", json_string_value(json_object_get(j_element, "match"))) && 0 != o_strcmp("startswith", json_string_value(json_object_get(j_element, "match"))) && 0 != o_strcmp("endswith", json_string_value(json_object_get(j_element, "match"))))) {
             json_array_append_new(j_error, json_string("match is mandatory and must have one of the following values: 'equals', 'contains', 'startswith', 'endswith'"));
           }
         }

--- a/src/user/ldap.c
+++ b/src/user/ldap.c
@@ -170,7 +170,7 @@ static json_t * is_user_ldap_parameters_valid(json_t * j_params, int readonly) {
       if (json_object_get(j_params, "scope-match") != NULL && !json_is_array(json_object_get(j_params, "scope-match"))) {
         json_array_append_new(j_error, json_string("scope-match is optional and must be a JSON array"));
       } else if (json_object_get(j_params, "scope-match") != NULL) {
-        json_array_foreach(json_object_get(j_params, "scope-property-match-correspondence"), index, j_element) {
+        json_array_foreach(json_object_get(j_params, "scope-match"), index, j_element) {
           if (!json_is_string(json_object_get(j_element, "ldap-value"))) {
             json_array_append_new(j_error, json_string("ldap-value is mandatory and must be a string"));
           }
@@ -1073,16 +1073,19 @@ static LDAPMod ** get_ldap_write_mod(json_t * j_params, LDAP * ldap, const char 
 
 static json_t * get_scope_from_ldap(json_t * j_params, const char * ldap_scope_value) {
   json_t * j_element = NULL;
-  const char * key = NULL, * value;
+  size_t index = 0;
+  const char * value, * scope, * match;
 
-  if (json_object_get(j_params, "scope-property-match-correspondence") != NULL) {
-    json_object_foreach(json_object_get(j_params, "scope-property-match-correspondence"), key, j_element) {
-      value = json_string_value(j_element);
-      if ((0 == o_strcmp("equals", json_string_value(json_object_get(j_params, "scope-property-match"))) && 0 == o_strcmp(value, ldap_scope_value)) ||
-          (0 == o_strcmp("contains", json_string_value(json_object_get(j_params, "scope-property-match"))) && NULL != o_strstr(ldap_scope_value, value)) ||
-          (0 == o_strcmp("starts-with", json_string_value(json_object_get(j_params, "scope-property-match"))) && 0 != o_strncmp(ldap_scope_value, value, o_strlen(value))) ||
-          (0 == o_strcmp("ends-with", json_string_value(json_object_get(j_params, "scope-property-match"))) && 0 != strcmp(ldap_scope_value + o_strlen(ldap_scope_value) - o_strlen(value), value))) {
-        return json_string(key);
+  if (json_object_get(j_params, "scope-match") != NULL) {
+    json_array_foreach(json_object_get(j_params, "scope-match"), index, j_element) {
+      value = json_string_value(json_object_get(j_element, "ldap-value"));
+      scope = json_string_value(json_object_get(j_element, "scope-value"));
+      match = json_string_value(json_object_get(j_element, "match"));
+      if ((0 == o_strcmp("equals", match) && 0 == o_strcmp(value, ldap_scope_value)) ||
+          (0 == o_strcmp("contains", match) && NULL != o_strstr(ldap_scope_value, value)) ||
+          (0 == o_strcmp("starts-with", match) && 0 != o_strncmp(ldap_scope_value, value, o_strlen(value))) ||
+          (0 == o_strcmp("ends-with", match) && 0 != strcmp(ldap_scope_value + o_strlen(ldap_scope_value) - o_strlen(value), value))) {
+        return json_string(scope);
       }
     }
   }


### PR DESCRIPTION
Hello there,

Thank you for bringing up Glewlwyd! I recently came across Glewlwyd and decided to use it as an SSO server for self-hosting. However, I encountered an issue while using the LDAP user module. It seems that I couldn't bind LDAP's groups to Glewlwyd scopes, as mentioned in the documentation here: [USER_LDAP.md](https://github.com/babelouest/glewlwyd/blob/master/docs/USER_LDAP.md#scope-field-property).

Currently, the LDAP users' scopes only contain origin values in the scope property. To address this problem, I have created a Pull Request that proposes a solution. I have already tested this fix on my own setup.